### PR TITLE
ADD: Missing translations for ServerConfigTabs & Page component

### DIFF
--- a/frontend/src/app/dashboard/[server]/page.tsx
+++ b/frontend/src/app/dashboard/[server]/page.tsx
@@ -10,6 +10,8 @@ import { ServerConfigTabs } from "@/components/organisms/ServerConfigTabs";
 import { Skeleton } from "@/components/ui/skeleton";
 import { motion } from "framer-motion";
 import Image from "next/image";
+import { useLanguage } from "@/lib/hooks/useLanguage";
+
 
 export default function ServerConfig() {
   const router = useRouter();
@@ -18,6 +20,7 @@ export default function ServerConfig() {
 
   const { config, loading: configLoading, updateConfig, saveConfig, restartServer, clearServerData } = useServerConfig(serverId);
   const { status, isProcessingAction, startServer, stopServer } = useServerStatus(serverId);
+  const { t } = useLanguage();
 
   // Auth check
   useEffect(() => {
@@ -137,22 +140,22 @@ export default function ServerConfig() {
       <motion.div initial={{ opacity: 0, y: 20 }} animate={{ opacity: 1, y: 0 }} transition={{ duration: 0.5, delay: 0.8 }} className="bg-gray-900/60 backdrop-blur-md rounded-lg border border-gray-700/40 p-6">
         <div className="flex items-center gap-3 mb-4">
           <Image src="/images/command-block.webp" alt="Command Block" width={24} height={24} />
-          <h3 className="text-lg font-minecraft text-white">Información del Servidor</h3>
+          <h3 className="text-lg font-minecraft text-white">{ t("serverInformation") }</h3>
         </div>
         <div className="grid grid-cols-1 md:grid-cols-3 gap-4 text-sm">
           <div className="bg-gray-800/40 rounded-lg p-3 border border-gray-700/30">
-            <p className="text-gray-400 mb-1">ID del Servidor</p>
+            <p className="text-gray-400 mb-1">{ t("serverId")}</p>
             <p className="text-white font-medium font-minecraft">{serverId}</p>
           </div>
           <div className="bg-gray-800/40 rounded-lg p-3 border border-gray-700/30">
-            <p className="text-gray-400 mb-1">Estado Actual</p>
+            <p className="text-gray-400 mb-1">{ t("currentStatus")} </p>
             <div className="flex items-center gap-2">
               <div className={`w-2 h-2 rounded-full ${status === "running" ? "bg-emerald-500" : status === "stopped" ? "bg-yellow-500" : status === "starting" ? "bg-orange-500" : "bg-red-500"}`} />
               <p className="text-white font-medium capitalize">{status}</p>
             </div>
           </div>
           <div className="bg-gray-800/40 rounded-lg p-3 border border-gray-700/30">
-            <p className="text-gray-400 mb-1">Puerto</p>
+            <p className="text-gray-400 mb-1">{ t('port')} </p>
             <p className="text-white font-medium">{config.port || "25565"}</p>
           </div>
         </div>

--- a/frontend/src/components/organisms/ServerConfigTabs.tsx
+++ b/frontend/src/components/organisms/ServerConfigTabs.tsx
@@ -44,7 +44,7 @@ export const ServerConfigTabs: FC<ServerConfigTabsProps> = ({ serverId, config, 
             <TabsList className="flex w-max min-w-full h-auto p-1 bg-gray-800/70 border-b border-gray-700/60">
               <TabsTrigger value="type" className="flex text-gray-200 items-center gap-1.5 py-2.5 px-3 data-[state=active]:bg-emerald-600/20 data-[state=active]:text-emerald-400 data-[state=active]:border-b-2 data-[state=active]:border-emerald-500 font-minecraft text-sm whitespace-nowrap">
                 <Server className="h-4 w-4" />
-                <span className="hidden sm:inline">{t("serverType")}</span>
+                <span className="hidden sm:inline">{ t("serverType") }</span>
                 <span className="sm:hidden">Tipo</span>
               </TabsTrigger>
 
@@ -56,7 +56,7 @@ export const ServerConfigTabs: FC<ServerConfigTabsProps> = ({ serverId, config, 
 
               <TabsTrigger value="resources" className="flex text-gray-200 items-center gap-1.5 py-2.5 px-3 data-[state=active]:bg-emerald-600/20 data-[state=active]:text-emerald-400 data-[state=active]:border-b-2 data-[state=active]:border-emerald-500 font-minecraft text-sm whitespace-nowrap">
                 <Cpu className="h-4 w-4" />
-                <span className="hidden sm:inline">Recursos</span>
+                <span className="hidden sm:inline"> { t("resources") }</span>
                 <span className="sm:hidden">Recursos</span>
               </TabsTrigger>
 
@@ -78,8 +78,8 @@ export const ServerConfigTabs: FC<ServerConfigTabsProps> = ({ serverId, config, 
 
               <TabsTrigger value="advanced" className="flex text-gray-200 items-center gap-1.5 py-2.5 px-3 data-[state=active]:bg-emerald-600/20 data-[state=active]:text-emerald-400 data-[state=active]:border-b-2 data-[state=active]:border-emerald-500 font-minecraft text-sm whitespace-nowrap">
                 <Code className="h-4 w-4" />
-                <span className="hidden sm:inline">Avanzado</span>
-                <span className="sm:hidden">Avanzado</span>
+                <span className="hidden sm:inline">{ t("advanced") }</span>
+                <span className="sm:hidden">{ t("advanced") }</span>
               </TabsTrigger>
 
               <TabsTrigger value="logs" className="flex text-gray-200 items-center gap-1.5 py-2.5 px-3 data-[state=active]:bg-emerald-600/20 data-[state=active]:text-emerald-400 data-[state=active]:border-b-2 data-[state=active]:border-emerald-500 font-minecraft text-sm whitespace-nowrap">
@@ -90,7 +90,7 @@ export const ServerConfigTabs: FC<ServerConfigTabsProps> = ({ serverId, config, 
 
               <TabsTrigger value="commands" className="flex text-gray-200 items-center gap-1.5 py-2.5 px-3 data-[state=active]:bg-emerald-600/20 data-[state=active]:text-emerald-400 data-[state=active]:border-b-2 data-[state=active]:border-emerald-500 font-minecraft text-sm whitespace-nowrap">
                 <Terminal className="h-4 w-4" />
-                <span className="hidden sm:inline">Comandos</span>
+                <span className="hidden sm:inline">{ t("commands") }</span>
                 <span className="sm:hidden">CMD</span>
               </TabsTrigger>
             </TabsList>

--- a/frontend/src/lib/translations/en.ts
+++ b/frontend/src/lib/translations/en.ts
@@ -469,4 +469,12 @@ export const en = {
   pluginsOpenPluginsFolder: "Open plugins folder",
   pluginsOpenServerFolder: "Open server folder",
   openFileBrowser: "File Manager",
+
+  // Page component
+  serverInformation: "Server Information",
+  currentStatus: "Current Status",
+
+  // ServerConfigTab Component
+  advanced: "Advanced",
+  commands: "Commands"
 };

--- a/frontend/src/lib/translations/es.ts
+++ b/frontend/src/lib/translations/es.ts
@@ -469,6 +469,15 @@ export const es = {
   pluginsOpenPluginsFolder: "Abrir carpeta de plugins",
   pluginsOpenServerFolder: "Abrir carpeta del servidor",
   openFileBrowser: "Gestor de archivos",
+
+  // Page Component
+  serverInformation: "Información del Servidor",
+  currentStatus: "Estado Actual",
+
+  // ServerConfigTab Component
+  advanced: "Avanzado",
+  commands: "Comandos"
+
 };
 
 export type TranslationKey = keyof typeof es;


### PR DESCRIPTION
### What did you implement:
- Added English translation for Page component.
- Added English translation for ServerConfigTabs component.

### Steps to test the changes:
1. Set language in .env to "en"
2. Login as user.
3. Select a server (or create a new one if you don't have one)
4. Click on Configure
5. Check if tabs are now in English
6. Check if "Server Information" card is now in English.

### **Copilot Summary**
This pull request introduces internationalization (i18n) improvements to the server dashboard, making key UI texts translatable and ensuring a more consistent multilingual experience. The changes focus on replacing hardcoded Spanish strings with translation keys and updating translation files for both English and Spanish.

**Internationalization of dashboard UI:**

* Added usage of the `useLanguage` hook and translation function `t` to `ServerConfig` and `ServerConfigTabs` components, replacing hardcoded UI strings with translation keys for server information, status, port, and tab labels. ([frontend/src/app/dashboard/[server]/page.tsxR13-R14](diffhunk://#diff-5d19c585da7c52c7bf030ce8b6ccbece9f1d51ddd2f7c535152aeff91ea6834dR13-R14), [frontend/src/app/dashboard/[server]/page.tsxR23](diffhunk://#diff-5d19c585da7c52c7bf030ce8b6ccbece9f1d51ddd2f7c535152aeff91ea6834dR23), [frontend/src/app/dashboard/[server]/page.tsxL140-R158](diffhunk://#diff-5d19c585da7c52c7bf030ce8b6ccbece9f1d51ddd2f7c535152aeff91ea6834dL140-R158), [[1]](diffhunk://#diff-d73006f6f1195cef34aeb43e36c1dbe324b9acf3abb90f3cd22865872afb94eeL59-R59) [[2]](diffhunk://#diff-d73006f6f1195cef34aeb43e36c1dbe324b9acf3abb90f3cd22865872afb94eeL81-R82) [[3]](diffhunk://#diff-d73006f6f1195cef34aeb43e36c1dbe324b9acf3abb90f3cd22865872afb94eeL93-R93)

**Translation file updates:**

* Updated `en.ts` and `es.ts` translation files to include new keys for server information, current status, advanced tab, and commands tab, ensuring proper translations in both languages. [[1]](diffhunk://#diff-9244eca6d6bb35e8f059f119ac640e001817d1a88cba2d3dccedf90507926a85R472-R479) [[2]](diffhunk://#diff-8f2981e24698f347eed8d419189d81c5cd02e5244f75da4e818bd97235d650ddR472-R480)