### PR TITLE
Replace hardcoded JWT secret with environment variable

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,4 +1,9 @@
 FRONTEND_URL= 'http://localhost:8090' # URL of the frontend application
+
+# SECURITY: JWT Secret - REQUIRED
+# Generate a strong random secret: openssl rand -base64 32
+JWT_SECRET= # Example: your-super-secret-jwt-key-change-this-in-production
+
 # IMPORTANT: If your CurseForge API key or any bcrypt hash contains '$', you must double each '$' (e.g. $$2a$$12$$...)
 CF_API_KEY= # CurseForge API key for authentication. Example with doubled $: $$2a$$10$$T6sGluhpKpqowKQg6ZSFQ.ZabIa4UGcAxtaQSBd1TiF3ExzWqzcMa (it's not necessary this env variable)
 CLIENT_PASSWORD= # Hash password for the client. Example: $2a$12$.smCPAhCsEHAJopMPSvdQOARSnPc4wNUzF4a6hS/F/JJe8YpaI4y. (for 'hola123')

--- a/backend/src/auth/auth.module.ts
+++ b/backend/src/auth/auth.module.ts
@@ -1,6 +1,7 @@
 import { Module } from '@nestjs/common';
 import { JwtModule } from '@nestjs/jwt';
 import { PassportModule } from '@nestjs/passport';
+import { ConfigModule, ConfigService } from '@nestjs/config';
 import { AuthService } from './auth.service';
 import { AuthController } from './auth.controller';
 import { JwtStrategy } from './jwt.strategy';
@@ -9,9 +10,21 @@ import { LocalStrategy } from './local.strategy';
 @Module({
   imports: [
     PassportModule,
-    JwtModule.register({
-      secret: 'mineminenomi-secret-key', // In production, use environment variables
-      signOptions: { expiresIn: '24h' }, // Token valid for 24 hours
+    JwtModule.registerAsync({
+      imports: [ConfigModule],
+      inject: [ConfigService],
+      useFactory: async (configService: ConfigService) => {
+        const jwtSecret = configService.get<string>('JWT_SECRET');
+        
+        if (!jwtSecret) {
+          throw new Error('JWT_SECRET environment variable is not set. Please configure it in your .env file.');
+        }
+
+        return {
+          secret: jwtSecret,
+          signOptions: { expiresIn: '24h' },
+        };
+      },
     }),
   ],
   providers: [AuthService, LocalStrategy, JwtStrategy],

--- a/backend/src/auth/jwt.strategy.ts
+++ b/backend/src/auth/jwt.strategy.ts
@@ -1,14 +1,21 @@
 import { ExtractJwt, Strategy } from 'passport-jwt';
 import { PassportStrategy } from '@nestjs/passport';
 import { Injectable } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
 
 @Injectable()
 export class JwtStrategy extends PassportStrategy(Strategy) {
-  constructor() {
+  constructor(private configService: ConfigService) {
+    const jwtSecret = configService.get<string>('JWT_SECRET');
+    
+    if (!jwtSecret) {
+      throw new Error('JWT_SECRET environment variable is not set. Please configure it in your .env file.');
+    }
+
     super({
       jwtFromRequest: ExtractJwt.fromAuthHeaderAsBearerToken(),
       ignoreExpiration: false,
-      secretOrKey: 'mineminenomi-secret-key', // In production, use environment variables
+      secretOrKey: jwtSecret,
     });
   }
 

--- a/docker-compose.split.yml
+++ b/docker-compose.split.yml
@@ -7,6 +7,7 @@ services:
       - NODE_ENV=production
       - SERVERS_DIR=${PWD}/servers
       - FRONTEND_URL=${FRONTEND_URL:-http://localhost:3000}
+      - JWT_SECRET=${JWT_SECRET:?JWT_SECRET environment variable is required. Generate one with: openssl rand -base64 32}
       - CLIENT_PASSWORD=${CLIENT_PASSWORD:-$$2a$$12$$kvlrbEjbVd6SsbD8JdIB.OOQWXTPL5dFgo5nDeIXgeW.BhIyy8ocu}
       - CLIENT_USERNAME=${CLIENT_USERNAME:-admin}
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,7 @@ services:
       # Backend environment variables
       - SERVERS_DIR=${PWD}/servers
       - FRONTEND_URL=${FRONTEND_URL:-http://localhost:3000}
+      - JWT_SECRET=${JWT_SECRET:?JWT_SECRET environment variable is required. Generate one with: openssl rand -base64 32}
       - CLIENT_PASSWORD=${CLIENT_PASSWORD:-$$2a$$12$$kvlrbEjbVd6SsbD8JdIB.OOQWXTPL5dFgo5nDeIXgeW.BhIyy8ocu}
       - CLIENT_USERNAME=${CLIENT_USERNAME:-admin}
       - DEFAULT_LANGUAGE=${DEFAULT_LANGUAGE:-en}


### PR DESCRIPTION
## Summary
Removes hardcoded JWT secret and implements secure configuration via environment variables to prevent authentication bypass vulnerabilities.

## Security Issue
The application previously used a hardcoded JWT secret (`mineminenomi-secret-key`) that was publicly visible in the repository. This allowed anyone to generate valid authentication tokens and bypass authentication entirely.

## Breaking Change
**This is a breaking change.** Users must now set the `JWT_SECRET` environment variable before running the application.
