### PR TITLE
chore: add BASE_DIR environment variable to docker-compose files

### DIFF
--- a/docker-compose.example.yml
+++ b/docker-compose.example.yml
@@ -10,6 +10,7 @@ services:
       - JWT_SECRET=${JWT_SECRET}
       - CLIENT_PASSWORD=${CLIENT_PASSWORD:-admin}
       - CLIENT_USERNAME=${CLIENT_USERNAME:-admin}
+      - BASE_DIR=${BASE_DIR:-$PWD}
       # - HOST_LAN_IP=${HOST_LAN_IP}
     volumes:
       - ${BASE_DIR:-$PWD}/servers:/app/servers

--- a/docker-compose.split.yml
+++ b/docker-compose.split.yml
@@ -9,6 +9,7 @@ services:
       - JWT_SECRET=${JWT_SECRET}
       - CLIENT_PASSWORD=${CLIENT_PASSWORD:-admin}
       - CLIENT_USERNAME=${CLIENT_USERNAME:-admin}
+      - BASE_DIR=${BASE_DIR:-$PWD}
       # - HOST_LAN_IP=${HOST_LAN_IP}
     volumes:
       - ${BASE_DIR:-$PWD}/servers:/app/servers

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,7 @@ services:
       - JWT_SECRET=${JWT_SECRET} # JWT_SECRET environment variable is required. Generate one with: openssl rand -base64 32
       - CLIENT_PASSWORD=${CLIENT_PASSWORD:-admin}
       - CLIENT_USERNAME=${CLIENT_USERNAME:-admin}
+      - BASE_DIR=${BASE_DIR:-$PWD}
       # - HOST_LAN_IP=${HOST_LAN_IP}
 
       # Frontend Configuration (loaded at runtime)


### PR DESCRIPTION
- Introduced BASE_DIR variable to docker-compose configurations to standardize the base directory path for server volumes.
- Updated all relevant docker-compose files to utilize the new BASE_DIR variable, defaulting to the current working directory if not set.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds `BASE_DIR` env to all docker-compose variants and switches volume mounts to `${BASE_DIR:-$PWD}`.
> 
> - **Docker Compose configs**:
>   - Add `BASE_DIR=${BASE_DIR:-$PWD}` to environments in `docker-compose.yml`, `docker-compose.split.yml`, and `docker-compose.example.yml`.
>   - Update volume mounts to use `${BASE_DIR:-$PWD}` for `servers` and `data` paths.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 043894105378ee542c7dc2e5c456f5f1e6c554e4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->