### PR TITLE
feat: implement insecure cookie handling for HTTP access and update d…

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -41,6 +41,8 @@ docker compose up -d
 
 Open http://localhost:3000 — Login: `admin` / `admin`
 
+If you access Minepanel over plain HTTP by local IP and login gets stuck on "Verifying authentication...", see the [Configuration](https://minepanel.ketbome.com/configuration) docs for `ALLOW_INSECURE_AUTH_COOKIES`.
+
 ---
 
 ## Features

--- a/backend/src/auth/auth.controller.spec.ts
+++ b/backend/src/auth/auth.controller.spec.ts
@@ -9,8 +9,15 @@ describe('AuthController', () => {
   let authService: jest.Mocked<AuthService>;
   let mockResponse: Partial<Response>;
   let mockRequest: Partial<Request>;
+  let originalNodeEnv: string | undefined;
+  let originalAllowInsecureCookies: string | undefined;
 
   beforeEach(async () => {
+    originalNodeEnv = process.env.NODE_ENV;
+    originalAllowInsecureCookies = process.env.ALLOW_INSECURE_AUTH_COOKIES;
+    process.env.NODE_ENV = 'test';
+    delete process.env.ALLOW_INSECURE_AUTH_COOKIES;
+
     const mockAuthService = {
       validateUser: jest.fn(),
       generateJwt: jest.fn(),
@@ -35,6 +42,19 @@ describe('AuthController', () => {
 
     controller = module.get<AuthController>(AuthController);
     authService = module.get(AuthService);
+  });
+
+  afterEach(() => {
+    if (originalNodeEnv === undefined) {
+      delete process.env.NODE_ENV;
+    } else {
+      process.env.NODE_ENV = originalNodeEnv;
+    }
+    if (originalAllowInsecureCookies === undefined) {
+      delete process.env.ALLOW_INSECURE_AUTH_COOKIES;
+    } else {
+      process.env.ALLOW_INSECURE_AUTH_COOKIES = originalAllowInsecureCookies;
+    }
   });
 
   it('should be defined', () => {
@@ -62,6 +82,87 @@ describe('AuthController', () => {
       expect(mockResponse.cookie).toHaveBeenCalledTimes(2);
       expect(mockResponse.cookie).toHaveBeenCalledWith('access_token', 'jwt.access.token', expect.any(Object));
       expect(mockResponse.cookie).toHaveBeenCalledWith('refresh_token', 'jwt.refresh.token', expect.any(Object));
+    });
+
+    it('should set secure cookies in production by default', async () => {
+      process.env.NODE_ENV = 'production';
+      delete process.env.ALLOW_INSECURE_AUTH_COOKIES;
+
+      const mockPayload = { userId: 1, username: 'admin', role: 'ADMIN' };
+      authService.validateUser.mockResolvedValue(mockPayload);
+      authService.generateJwt.mockResolvedValue({
+        access_token: 'jwt.access.token',
+        refresh_token: 'jwt.refresh.token',
+        username: 'admin',
+        expires_in: 900,
+      });
+
+      await controller.login({ username: 'admin', password: 'password' }, mockResponse as Response);
+
+      expect(mockResponse.cookie).toHaveBeenCalledWith(
+        'access_token',
+        'jwt.access.token',
+        expect.objectContaining({ secure: true, httpOnly: true, sameSite: 'lax' }),
+      );
+      expect(mockResponse.cookie).toHaveBeenCalledWith(
+        'refresh_token',
+        'jwt.refresh.token',
+        expect.objectContaining({ secure: true, httpOnly: true, sameSite: 'lax' }),
+      );
+    });
+
+    it('should set insecure cookies when ALLOW_INSECURE_AUTH_COOKIES=true in production', async () => {
+      process.env.NODE_ENV = 'production';
+      process.env.ALLOW_INSECURE_AUTH_COOKIES = 'true';
+
+      const mockPayload = { userId: 1, username: 'admin', role: 'ADMIN' };
+      authService.validateUser.mockResolvedValue(mockPayload);
+      authService.generateJwt.mockResolvedValue({
+        access_token: 'jwt.access.token',
+        refresh_token: 'jwt.refresh.token',
+        username: 'admin',
+        expires_in: 900,
+      });
+
+      await controller.login({ username: 'admin', password: 'password' }, mockResponse as Response);
+
+      expect(mockResponse.cookie).toHaveBeenCalledWith(
+        'access_token',
+        'jwt.access.token',
+        expect.objectContaining({ secure: false, httpOnly: true, sameSite: 'lax' }),
+      );
+      expect(mockResponse.cookie).toHaveBeenCalledWith(
+        'refresh_token',
+        'jwt.refresh.token',
+        expect.objectContaining({ secure: false, httpOnly: true, sameSite: 'lax' }),
+      );
+    });
+
+    it('should set insecure cookies in development mode', async () => {
+      process.env.NODE_ENV = 'development';
+      delete process.env.ALLOW_INSECURE_AUTH_COOKIES;
+
+      const mockPayload = { userId: 1, username: 'admin', role: 'ADMIN' };
+      authService.validateUser.mockResolvedValue(mockPayload);
+      authService.generateJwt.mockResolvedValue({
+        access_token: 'jwt.access.token',
+        refresh_token: 'jwt.refresh.token',
+        username: 'admin',
+        expires_in: 900,
+      });
+
+      await controller.login({ username: 'admin', password: 'password' }, mockResponse as Response);
+
+      expect(mockResponse.cookie).toHaveBeenCalledWith(
+        'access_token',
+        'jwt.access.token',
+        expect.objectContaining({ secure: false, httpOnly: true, sameSite: 'lax' }),
+      );
+      expect(mockResponse.cookie).toHaveBeenCalledWith(
+        'refresh_token',
+        'jwt.refresh.token',
+        expect.objectContaining({ secure: false, httpOnly: true, sameSite: 'lax' }),
+      );
     });
 
     it('should throw UnauthorizedException on invalid credentials', async () => {

--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -2,10 +2,13 @@ import { Controller, Post, Body, UnauthorizedException, UseGuards, Res, Req, Get
 import { AuthService } from './auth.service';
 import { AuthGuard } from '@nestjs/passport';
 import { JwtAuthGuard } from './guards/auth.guard';
-import { Response, Request } from 'express';
+import { Response, Request, CookieOptions } from 'express';
 
 @Controller('auth')
 export class AuthController {
+  private static readonly ACCESS_TOKEN_MAX_AGE = 15 * 60 * 1000; // 15 minutes
+  private static readonly REFRESH_TOKEN_MAX_AGE = 7 * 24 * 60 * 60 * 1000; // 7 days
+
   constructor(private readonly authService: AuthService) {}
 
   @UseGuards(AuthGuard('local'))
@@ -20,19 +23,8 @@ export class AuthController {
     const tokens = await this.authService.generateJwt(user);
     
     // Set httpOnly cookies
-    res.cookie('access_token', tokens.access_token, {
-      httpOnly: true,
-      secure: process.env.NODE_ENV === 'production',
-      sameSite: 'lax',
-      maxAge: 15 * 60 * 1000, // 15 minutes
-    });
-    
-    res.cookie('refresh_token', tokens.refresh_token, {
-      httpOnly: true,
-      secure: process.env.NODE_ENV === 'production',
-      sameSite: 'lax',
-      maxAge: 7 * 24 * 60 * 60 * 1000, // 7 days
-    });
+    res.cookie('access_token', tokens.access_token, this.getAuthCookieOptions(AuthController.ACCESS_TOKEN_MAX_AGE));
+    res.cookie('refresh_token', tokens.refresh_token, this.getAuthCookieOptions(AuthController.REFRESH_TOKEN_MAX_AGE));
     
     return {
       username: tokens.username,
@@ -72,19 +64,8 @@ export class AuthController {
     const tokens = await this.authService.generateJwt(user);
     
     // Update cookies with new tokens
-    res.cookie('access_token', tokens.access_token, {
-      httpOnly: true,
-      secure: process.env.NODE_ENV === 'production',
-      sameSite: 'lax',
-      maxAge: 15 * 60 * 1000,
-    });
-    
-    res.cookie('refresh_token', tokens.refresh_token, {
-      httpOnly: true,
-      secure: process.env.NODE_ENV === 'production',
-      sameSite: 'lax',
-      maxAge: 7 * 24 * 60 * 60 * 1000,
-    });
+    res.cookie('access_token', tokens.access_token, this.getAuthCookieOptions(AuthController.ACCESS_TOKEN_MAX_AGE));
+    res.cookie('refresh_token', tokens.refresh_token, this.getAuthCookieOptions(AuthController.REFRESH_TOKEN_MAX_AGE));
     
     return {
       username: tokens.username,
@@ -107,5 +88,21 @@ export class AuthController {
     res.clearCookie('refresh_token');
     
     return { message: 'Logged out successfully' };
+  }
+
+  private getAuthCookieOptions(maxAge: number): CookieOptions {
+    return {
+      httpOnly: true,
+      secure: this.shouldUseSecureCookies(),
+      sameSite: 'lax',
+      maxAge,
+    };
+  }
+
+  private shouldUseSecureCookies(): boolean {
+    if (process.env.ALLOW_INSECURE_AUTH_COOKIES === 'true') {
+      return false;
+    }
+    return process.env.NODE_ENV === 'production';
   }
 }

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -35,6 +35,7 @@ All variables can be set in `.env` or `docker-compose.yml`.
 | ----------------- | ------- | -------------- |
 | `CLIENT_USERNAME` | `admin` | Login username |
 | `CLIENT_PASSWORD` | `admin` | Login password |
+| `ALLOW_INSECURE_AUTH_COOKIES` | `false` | Set `true` only for HTTP/LAN access when browsers block auth cookies |
 
 ### URLs
 
@@ -46,6 +47,18 @@ All variables can be set in `.env` or `docker-compose.yml`.
 
 ::: danger CORS
 `FRONTEND_URL` **must match** how you access the panel. Mismatch = blocked requests.
+:::
+
+::: warning Authentication over HTTP
+In production, authentication cookies are secure by default. If you access Minepanel over plain HTTP (for example via local IP), browsers may reject secure cookies and login can get stuck on **"Verifying authentication..."**.
+
+You can explicitly opt in to HTTP auth cookies with:
+
+```bash
+ALLOW_INSECURE_AUTH_COOKIES=true
+```
+
+Use this only for trusted LAN/development environments. Prefer HTTPS whenever possible.
 :::
 
 ## Quick Reference

--- a/doc/getting-started.md
+++ b/doc/getting-started.md
@@ -85,6 +85,7 @@ To access from outside your network, update `docker-compose.yml`:
 environment:
   - FRONTEND_URL=http://your-ip:3000
   - NEXT_PUBLIC_BACKEND_URL=http://your-ip:8091
+  - ALLOW_INSECURE_AUTH_COOKIES=true # Only if staying on HTTP (LAN/dev)
 ```
 
 Then restart:
@@ -94,6 +95,11 @@ docker compose restart
 ```
 
 **→ Full guide:** [Networking](/networking)
+
+::: warning HTTP authentication
+`ALLOW_INSECURE_AUTH_COOKIES=true` is a fallback for HTTP-only setups.
+For production/public access, use HTTPS and keep this variable disabled.
+:::
 
 ## Next Steps
 

--- a/doc/installation.md
+++ b/doc/installation.md
@@ -32,6 +32,7 @@ Create a `.env` file for custom settings:
 ```bash
 # Authentication
 JWT_SECRET=your_secret_here  # openssl rand -base64 32
+ALLOW_INSECURE_AUTH_COOKIES=false  # Set true only if using HTTP (LAN/dev)
 
 # Ports (optional)
 FRONTEND_PORT=3000
@@ -42,6 +43,11 @@ BASE_DIR=$PWD
 ```
 
 **→ All variables:** [Configuration](/configuration)
+
+::: tip HTTP access note
+If you access Minepanel via plain HTTP (local IP) and login gets stuck on "Verifying authentication...", set `ALLOW_INSECURE_AUTH_COOKIES=true`.
+Use this only on trusted networks and prefer HTTPS.
+:::
 
 ## Update
 

--- a/doc/troubleshooting.md
+++ b/doc/troubleshooting.md
@@ -225,6 +225,33 @@ docker compose up -d
 
 See [Password Management](/administration#password-management).
 
+### Stuck on "Verifying authentication..."
+
+**Symptoms:** Login appears successful, but dashboard keeps loading on "Verifying authentication...".
+
+**Cause:** Browser is rejecting auth cookies because they are marked `Secure` while the panel is being accessed over plain HTTP.
+
+**Quick checks:**
+
+1. Open browser DevTools → **Network** and inspect `/auth/me` response (usually `401` in this case).
+2. Open DevTools → **Application/Storage → Cookies** and verify whether `access_token`/`refresh_token` are being stored.
+
+**Solutions:**
+
+1. **Recommended:** Use HTTPS and set `FRONTEND_URL` / `NEXT_PUBLIC_BACKEND_URL` to `https://...`.
+2. **HTTP fallback (LAN/dev only):** Enable insecure auth cookies explicitly:
+
+```yaml
+environment:
+  - ALLOW_INSECURE_AUTH_COOKIES=true
+```
+
+Then restart Minepanel:
+
+```bash
+docker compose restart
+```
+
 ### JWT Token Errors
 
 **Error:** "Invalid token" or "Token expired"

--- a/docker-compose.development.yml
+++ b/docker-compose.development.yml
@@ -10,6 +10,7 @@ services:
       - JWT_SECRET=${JWT_SECRET}
       - CLIENT_PASSWORD=${CLIENT_PASSWORD:-admin}
       - CLIENT_USERNAME=${CLIENT_USERNAME:-admin}
+      - ALLOW_INSECURE_AUTH_COOKIES=${ALLOW_INSECURE_AUTH_COOKIES:-false}
       - BASE_DIR=${BASE_DIR:-$PWD}
       # - BASE_PATH=${BASE_PATH}  # Subdirectory routing (e.g., /api)
     volumes:

--- a/docker-compose.single.yml
+++ b/docker-compose.single.yml
@@ -10,6 +10,7 @@ services:
       - JWT_SECRET=${JWT_SECRET} # JWT_SECRET environment variable is required. Generate one with: openssl rand -base64 32
       - CLIENT_PASSWORD=${CLIENT_PASSWORD:-admin}
       - CLIENT_USERNAME=${CLIENT_USERNAME:-admin}
+      - ALLOW_INSECURE_AUTH_COOKIES=${ALLOW_INSECURE_AUTH_COOKIES:-false}
       - BASE_DIR=${BASE_DIR:-$PWD}
 
       # Frontend Configuration (loaded at runtime)

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -19,6 +19,7 @@ services:
       - JWT_SECRET=${JWT_SECRET} # Required. Generate with: openssl rand -base64 32
       - CLIENT_PASSWORD=${CLIENT_PASSWORD:-admin}
       - CLIENT_USERNAME=${CLIENT_USERNAME:-admin}
+      - ALLOW_INSECURE_AUTH_COOKIES=${ALLOW_INSECURE_AUTH_COOKIES:-false}
       - BASE_DIR=${BASE_DIR:-$PWD}
     volumes:
       - ${BASE_DIR:-$PWD}/servers:/app/servers

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,7 @@ services:
       - JWT_SECRET=${JWT_SECRET} # Required. Generate with: openssl rand -base64 32
       - CLIENT_PASSWORD=${CLIENT_PASSWORD:-admin}
       - CLIENT_USERNAME=${CLIENT_USERNAME:-admin}
+      - ALLOW_INSECURE_AUTH_COOKIES=${ALLOW_INSECURE_AUTH_COOKIES:-false}
       - BASE_DIR=${BASE_DIR:-$PWD}
       # - BASE_PATH=${BASE_PATH}  # Subdirectory routing (e.g., /api)
     volumes:

--- a/env.example
+++ b/env.example
@@ -11,6 +11,7 @@
 JWT_SECRET=                                    # Generate with: openssl rand -base64 32
 CLIENT_USERNAME=admin
 CLIENT_PASSWORD=admin
+ALLOW_INSECURE_AUTH_COOKIES=false             # Set true only for HTTP/LAN setups (less secure)
 
 # -----------------------------------------------------------------------------
 # Directories

--- a/frontend/src/services/auth/auth.service.ts
+++ b/frontend/src/services/auth/auth.service.ts
@@ -2,6 +2,7 @@ import api from "../axios.service";
 
 let isRefreshing = false;
 let refreshSubscribers: Array<(token: string) => void> = [];
+const AUTH_ENDPOINTS = ["/auth/login", "/auth/refresh", "/auth/logout"];
 
 const onRefreshed = (token: string) => {
   refreshSubscribers.forEach((callback) => callback(token));
@@ -10,6 +11,11 @@ const onRefreshed = (token: string) => {
 
 const addRefreshSubscriber = (callback: (token: string) => void) => {
   refreshSubscribers.push(callback);
+};
+
+const isAuthEndpoint = (url?: string): boolean => {
+  if (!url) return false;
+  return AUTH_ENDPOINTS.some((endpoint) => url.includes(endpoint));
 };
 
 export const login = async (username: string, password: string) => {
@@ -76,8 +82,15 @@ export const setupAxiosInterceptors = () => {
     (response) => response,
     async (error) => {
       const originalRequest = error.config;
+      const status = error.response?.status;
+      const requestUrl = originalRequest?.url;
 
-      if (error.response?.status === 401 && !originalRequest._retry) {
+      // Never trigger token refresh on auth endpoints to avoid refresh loops.
+      if (status === 401 && isAuthEndpoint(requestUrl)) {
+        return Promise.reject(error);
+      }
+
+      if (status === 401 && originalRequest && !originalRequest._retry) {
         if (isRefreshing) {
           return new Promise((resolve) => {
             addRefreshSubscriber(() => {
@@ -108,4 +121,3 @@ export const setupAxiosInterceptors = () => {
 };
 
 if (globalThis.window !== undefined) setupAxiosInterceptors();
-

--- a/frontend/src/services/auth/auth.service.ts
+++ b/frontend/src/services/auth/auth.service.ts
@@ -1,16 +1,21 @@
 import api from "../axios.service";
 
 let isRefreshing = false;
-let refreshSubscribers: Array<(token: string) => void> = [];
+let refreshSubscribers: Array<{ onSuccess: () => void; onError: (error: unknown) => void }> = [];
 const AUTH_ENDPOINTS = ["/auth/login", "/auth/refresh", "/auth/logout"];
 
-const onRefreshed = (token: string) => {
-  refreshSubscribers.forEach((callback) => callback(token));
+const onRefreshed = () => {
+  refreshSubscribers.forEach((subscriber) => subscriber.onSuccess());
   refreshSubscribers = [];
 };
 
-const addRefreshSubscriber = (callback: (token: string) => void) => {
-  refreshSubscribers.push(callback);
+const onRefreshFailed = (error: unknown) => {
+  refreshSubscribers.forEach((subscriber) => subscriber.onError(error));
+  refreshSubscribers = [];
+};
+
+const addRefreshSubscriber = (onSuccess: () => void, onError: (error: unknown) => void) => {
+  refreshSubscribers.push({ onSuccess, onError });
 };
 
 const isAuthEndpoint = (url?: string): boolean => {
@@ -92,9 +97,11 @@ export const setupAxiosInterceptors = () => {
 
       if (status === 401 && originalRequest && !originalRequest._retry) {
         if (isRefreshing) {
-          return new Promise((resolve) => {
+          return new Promise((resolve, reject) => {
             addRefreshSubscriber(() => {
               resolve(api(originalRequest));
+            }, (refreshError) => {
+              reject(refreshError);
             });
           });
         }
@@ -106,10 +113,11 @@ export const setupAxiosInterceptors = () => {
 
         if (refreshed) {
           isRefreshing = false;
-          onRefreshed("refreshed");
+          onRefreshed();
           return api(originalRequest);
         } else {
           isRefreshing = false;
+          onRefreshFailed(error);
           await logout();
           throw error;
         }


### PR DESCRIPTION
## Description

Add optional HTTP auth-cookie support with an explicit opt-in flag, while keeping secure behavior by default.

### What changed
- Added `ALLOW_INSECURE_AUTH_COOKIES` support in auth cookie generation.
- Centralized cookie options in `AuthController` (`getAuthCookieOptions` + `shouldUseSecureCookies`).
- Preserved default behavior: in production, cookies remain `Secure=true` unless explicitly overridden.
- Added backend unit tests for:
  - Production default secure cookies
  - Production with `ALLOW_INSECURE_AUTH_COOKIES=true`
  - Development mode insecure cookies
- Updated docs and examples (`configuration`, `troubleshooting`, `installation`, `getting-started`, `Readme`) to explain the new flag and HTTP/HTTPS guidance.
- Added env/compose wiring:
  - `env.example`
  - `docker-compose.yml`
  - `docker-compose.single.yml`
  - `docker-compose.development.yml`
  - `docker-compose.test.yml`

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 📝 Documentation update
- [x] 🔧 Configuration change
- [x] ♻️ Refactoring (no functional changes)
- [x] 🧪 Tests

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have tested my changes locally
- [x] I have updated documentation if needed
- [x] My changes don't introduce new warnings or errors

## Screenshots (if applicable)

N/A (no UI changes)

## Related Issues

Closes issue: login stuck on **"Verifying authentication..."** in HTTP deployments due to secure cookie behavior.
