### PR TITLE
fix: update cookie handling and token expiration settings for improve…

### DIFF
--- a/backend/src/auth/auth.controller.spec.ts
+++ b/backend/src/auth/auth.controller.spec.ts
@@ -138,7 +138,7 @@ describe('AuthController', () => {
       );
     });
 
-    it('should set insecure cookies in development mode', async () => {
+    it('should set secure cookies in development mode by default', async () => {
       process.env.NODE_ENV = 'development';
       delete process.env.ALLOW_INSECURE_AUTH_COOKIES;
 
@@ -156,12 +156,12 @@ describe('AuthController', () => {
       expect(mockResponse.cookie).toHaveBeenCalledWith(
         'access_token',
         'jwt.access.token',
-        expect.objectContaining({ secure: false, httpOnly: true, sameSite: 'lax' }),
+        expect.objectContaining({ secure: true, httpOnly: true, sameSite: 'lax' }),
       );
       expect(mockResponse.cookie).toHaveBeenCalledWith(
         'refresh_token',
         'jwt.refresh.token',
-        expect.objectContaining({ secure: false, httpOnly: true, sameSite: 'lax' }),
+        expect.objectContaining({ secure: true, httpOnly: true, sameSite: 'lax' }),
       );
     });
 

--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -6,7 +6,6 @@ import { Response, Request, CookieOptions } from 'express';
 
 @Controller('auth')
 export class AuthController {
-  private static readonly ACCESS_TOKEN_MAX_AGE = 15 * 60 * 1000; // 15 minutes
   private static readonly REFRESH_TOKEN_MAX_AGE = 7 * 24 * 60 * 60 * 1000; // 7 days
 
   constructor(private readonly authService: AuthService) {}
@@ -23,7 +22,7 @@ export class AuthController {
     const tokens = await this.authService.generateJwt(user);
     
     // Set httpOnly cookies
-    res.cookie('access_token', tokens.access_token, this.getAuthCookieOptions(AuthController.ACCESS_TOKEN_MAX_AGE));
+    res.cookie('access_token', tokens.access_token, this.getAuthCookieOptions(tokens.expires_in * 1000));
     res.cookie('refresh_token', tokens.refresh_token, this.getAuthCookieOptions(AuthController.REFRESH_TOKEN_MAX_AGE));
     
     return {
@@ -64,7 +63,7 @@ export class AuthController {
     const tokens = await this.authService.generateJwt(user);
     
     // Update cookies with new tokens
-    res.cookie('access_token', tokens.access_token, this.getAuthCookieOptions(AuthController.ACCESS_TOKEN_MAX_AGE));
+    res.cookie('access_token', tokens.access_token, this.getAuthCookieOptions(tokens.expires_in * 1000));
     res.cookie('refresh_token', tokens.refresh_token, this.getAuthCookieOptions(AuthController.REFRESH_TOKEN_MAX_AGE));
     
     return {
@@ -100,9 +99,6 @@ export class AuthController {
   }
 
   private shouldUseSecureCookies(): boolean {
-    if (process.env.ALLOW_INSECURE_AUTH_COOKIES === 'true') {
-      return false;
-    }
-    return process.env.NODE_ENV === 'production';
+    return process.env.ALLOW_INSECURE_AUTH_COOKIES !== 'true';
   }
 }

--- a/backend/src/auth/auth.module.ts
+++ b/backend/src/auth/auth.module.ts
@@ -21,7 +21,7 @@ import { RefreshToken } from './entities/refresh-token.entity';
         return {
           secret: configService.get('jwtSecret'),
           signOptions: {
-            expiresIn: '15m',
+            expiresIn: configService.get('jwtExpiresIn') || '2d',
             issuer: configService.get('jwtIssuer'),
             audience: configService.get('jwtAudience'),
           },

--- a/backend/src/auth/auth.service.spec.ts
+++ b/backend/src/auth/auth.service.spec.ts
@@ -30,6 +30,7 @@ describe('AuthService', () => {
   beforeEach(async () => {
     const mockJwtService = {
       sign: jest.fn(),
+      decode: jest.fn(),
     };
 
     const mockUsersService = {
@@ -121,6 +122,7 @@ describe('AuthService', () => {
       const mockHashedToken = 'hashed.refresh.token';
       
       jwtService.sign.mockReturnValue(mockAccessToken);
+      jwtService.decode.mockReturnValue({ iat: 100, exp: 120 } as any);
       (bcrypt.hash as jest.Mock).mockResolvedValue(mockHashedToken);
       refreshTokenRepo.save.mockResolvedValue({} as any);
 
@@ -136,7 +138,7 @@ describe('AuthService', () => {
         access_token: mockAccessToken,
         refresh_token: 'mock-random-token',
         username: 'testuser',
-        expires_in: 900,
+        expires_in: 20,
       });
       expect(jwtService.sign).toHaveBeenCalledWith(payload);
       expect(refreshTokenRepo.save).toHaveBeenCalledWith(

--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -51,12 +51,14 @@ export class AuthService {
     
     const accessToken = this.jwtService.sign(payload);
     const refreshToken = await this.createRefreshToken(user.userId);
+    const decodedToken = this.jwtService.decode(accessToken) as { exp?: number; iat?: number } | null;
+    const expiresIn = decodedToken?.exp && decodedToken?.iat ? decodedToken.exp - decodedToken.iat : 900;
     
     return {
       access_token: accessToken,
       refresh_token: refreshToken,
       username: user.username,
-      expires_in: 900, // 15 minutes in seconds
+      expires_in: expiresIn,
     };
   }
 

--- a/backend/src/config.ts
+++ b/backend/src/config.ts
@@ -1,5 +1,6 @@
 export default () => ({
   jwtSecret: process.env.JWT_SECRET,
+  jwtExpiresIn: process.env.JWT_EXPIRES_IN || '2d',
   jwtIssuer: process.env.JWT_ISSUER || 'minepanel',
   jwtAudience: process.env.JWT_AUDIENCE || 'minepanel-users',
   clientUsername: process.env.CLIENT_USERNAME,

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -35,6 +35,7 @@ All variables can be set in `.env` or `docker-compose.yml`.
 | ----------------- | ------- | -------------- |
 | `CLIENT_USERNAME` | `admin` | Login username |
 | `CLIENT_PASSWORD` | `admin` | Login password |
+| `JWT_EXPIRES_IN` | `2d` | Access token expiration (`20s`, `15m`, `1h`, `2d`) |
 | `ALLOW_INSECURE_AUTH_COOKIES` | `false` | Set `true` only for HTTP/LAN access when browsers block auth cookies |
 
 ### URLs
@@ -68,6 +69,7 @@ Use this only for trusted LAN/development environments. Prefer HTTPS whenever po
 ```bash
 # .env
 JWT_SECRET=your_secret
+JWT_EXPIRES_IN=2d
 ```
 
 ### Remote Access
@@ -75,6 +77,7 @@ JWT_SECRET=your_secret
 ```bash
 # .env
 JWT_SECRET=your_secret
+JWT_EXPIRES_IN=2d
 FRONTEND_URL=http://your-ip:3000
 NEXT_PUBLIC_BACKEND_URL=http://your-ip:8091
 ```
@@ -84,6 +87,7 @@ NEXT_PUBLIC_BACKEND_URL=http://your-ip:8091
 ```bash
 # .env
 JWT_SECRET=your_secret
+JWT_EXPIRES_IN=2d
 FRONTEND_URL=https://minepanel.yourdomain.com
 NEXT_PUBLIC_BACKEND_URL=https://api.yourdomain.com
 ```

--- a/doc/development.md
+++ b/doc/development.md
@@ -81,6 +81,7 @@ Runs on `http://localhost:3000`
 FRONTEND_URL= 'http://localhost:3000' # URL of the frontend application
 # Generate a strong random secret: openssl rand -base64 32
 JWT_SECRET= # Example: your-super-secret-jwt-key-change-this-in-production
+JWT_EXPIRES_IN=2d # Access token expiration (use 20s to test refresh flow)
 CLIENT_PASSWORD= # Password for client
 CLIENT_USERNAME= # Username for the client
 DB_PATH=./data/minepanel.db

--- a/docker-compose.development.yml
+++ b/docker-compose.development.yml
@@ -8,6 +8,7 @@ services:
     environment:
       - FRONTEND_URL=${FRONTEND_URL:-http://localhost:3000}
       - JWT_SECRET=${JWT_SECRET}
+      - JWT_EXPIRES_IN=${JWT_EXPIRES_IN:-2d}
       - CLIENT_PASSWORD=${CLIENT_PASSWORD:-admin}
       - CLIENT_USERNAME=${CLIENT_USERNAME:-admin}
       - ALLOW_INSECURE_AUTH_COOKIES=${ALLOW_INSECURE_AUTH_COOKIES:-false}

--- a/docker-compose.single.yml
+++ b/docker-compose.single.yml
@@ -8,6 +8,7 @@ services:
       # Backend Configuration
       - FRONTEND_URL=${FRONTEND_URL:-http://localhost:3000}
       - JWT_SECRET=${JWT_SECRET} # JWT_SECRET environment variable is required. Generate one with: openssl rand -base64 32
+      - JWT_EXPIRES_IN=${JWT_EXPIRES_IN:-2d}
       - CLIENT_PASSWORD=${CLIENT_PASSWORD:-admin}
       - CLIENT_USERNAME=${CLIENT_USERNAME:-admin}
       - ALLOW_INSECURE_AUTH_COOKIES=${ALLOW_INSECURE_AUTH_COOKIES:-false}

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -17,6 +17,7 @@ services:
       - NODE_ENV=production
       - FRONTEND_URL=${FRONTEND_URL:-http://localhost:3000}
       - JWT_SECRET=${JWT_SECRET} # Required. Generate with: openssl rand -base64 32
+      - JWT_EXPIRES_IN=${JWT_EXPIRES_IN:-2d}
       - CLIENT_PASSWORD=${CLIENT_PASSWORD:-admin}
       - CLIENT_USERNAME=${CLIENT_USERNAME:-admin}
       - ALLOW_INSECURE_AUTH_COOKIES=${ALLOW_INSECURE_AUTH_COOKIES:-false}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,7 @@ services:
       - NODE_ENV=production
       - FRONTEND_URL=${FRONTEND_URL:-http://localhost:3000}
       - JWT_SECRET=${JWT_SECRET} # Required. Generate with: openssl rand -base64 32
+      - JWT_EXPIRES_IN=${JWT_EXPIRES_IN:-2d}
       - CLIENT_PASSWORD=${CLIENT_PASSWORD:-admin}
       - CLIENT_USERNAME=${CLIENT_USERNAME:-admin}
       - ALLOW_INSECURE_AUTH_COOKIES=${ALLOW_INSECURE_AUTH_COOKIES:-false}

--- a/env.example
+++ b/env.example
@@ -9,6 +9,7 @@
 # Authentication (Required)
 # -----------------------------------------------------------------------------
 JWT_SECRET=                                    # Generate with: openssl rand -base64 32
+JWT_EXPIRES_IN=2d                             # Access token TTL (e.g., 20s, 15m, 1h)
 CLIENT_USERNAME=admin
 CLIENT_PASSWORD=admin
 ALLOW_INSECURE_AUTH_COOKIES=false             # Set true only for HTTP/LAN setups (less secure)


### PR DESCRIPTION
## Description

Fixes the cookie-based authentication flow for local development (`http://localhost`) and updates JWT expiration configuration.

Main changes:
- Adjusts `ALLOW_INSECURE_AUTH_COOKIES` to allow local testing without HTTPS when needed.
- Adds/configures `JWT_EXPIRES_IN` to explicitly control `access_token` lifetime.
- Verifies that refresh token flow still works with rotation and revocation in `/auth/refresh`.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 📝 Documentation update
- [x] 🔧 Configuration change
- [ ] ♻️ Refactoring (no functional changes)
- [x] 🧪 Tests
