### PR TITLE
101 feature add support for compose project env variable

### DIFF
--- a/backend/src/config.ts
+++ b/backend/src/config.ts
@@ -6,6 +6,7 @@ export default () => ({
   clientUsername: process.env.CLIENT_USERNAME,
   clientPassword: process.env.CLIENT_PASSWORD,
   frontendUrl: process.env.FRONTEND_URL,
+  composeProject: process.env.COMPOSE_PROJECT,
   defaultLanguage: process.env.DEFAULT_LANGUAGE ?? 'en',
   serversDir: '/app/servers',
   baseDir: process.env.BASE_DIR || '/app',

--- a/backend/src/docker-compose/docker-compose.service.spec.ts
+++ b/backend/src/docker-compose/docker-compose.service.spec.ts
@@ -1,6 +1,8 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { ConfigService } from '@nestjs/config';
 import { DockerComposeService } from './docker-compose.service';
+import * as fs from 'fs-extra';
+import * as yaml from 'js-yaml';
 
 jest.mock('fs-extra', () => ({
   ensureDirSync: jest.fn(),
@@ -54,6 +56,32 @@ describe('DockerComposeService', () => {
     it('should return null when server does not exist', async () => {
       const result = await service.getServerConfig('nonexistent');
       expect(result).toBeNull();
+    });
+  });
+
+  describe('generateDockerComposeFile', () => {
+    it('should generate mc service without container_name', async () => {
+      const config = (service as any).createDefaultConfig('survival');
+
+      await service.generateDockerComposeFile(config, false);
+
+      const writeFileMock = fs.writeFile as unknown as jest.Mock;
+      const [, yamlContent] = writeFileMock.mock.calls[0];
+      const parsed = yaml.load(yamlContent as string) as any;
+
+      expect(parsed.services.mc.container_name).toBeUndefined();
+    });
+
+    it('should add stable proxy alias when proxy is enabled', async () => {
+      const config = (service as any).createDefaultConfig('proxyserver');
+
+      await service.generateDockerComposeFile(config, true);
+
+      const writeFileMock = fs.writeFile as unknown as jest.Mock;
+      const [, yamlContent] = writeFileMock.mock.calls[0];
+      const parsed = yaml.load(yamlContent as string) as any;
+
+      expect(parsed.services.mc.networks['minepanel-network'].aliases).toEqual(['proxyserver']);
     });
   });
 });

--- a/backend/src/docker-compose/docker-compose.service.ts
+++ b/backend/src/docker-compose/docker-compose.service.ts
@@ -1086,7 +1086,6 @@ export class DockerComposeService {
       image: strategy.getDockerImage(config.dockerImage),
       tty: true,
       stdin_open: true,
-      container_name: config.id,
       environment,
       volumes,
       restart: config.restartPolicy,
@@ -1105,7 +1104,11 @@ export class DockerComposeService {
     // Si usa proxy, no exponer puerto al host; si no, exponer como siempre
     if (useProxy) {
       mcService.expose = [internalPort];
-      mcService.networks = ['minepanel-network'];
+      mcService.networks = {
+        'minepanel-network': {
+          aliases: [config.id],
+        },
+      };
       if (config.extraPorts?.length) {
         mcService.ports = config.extraPorts;
       }

--- a/backend/src/server-management/server-management.service.spec.ts
+++ b/backend/src/server-management/server-management.service.spec.ts
@@ -47,6 +47,7 @@ describe('ServerManagementService', () => {
     const mockConfigService = {
       get: jest.fn((key: string) => {
         if (key === 'serversDir') return SERVERS_DIR;
+        if (key === 'baseDir') return '/app';
         return null;
       }),
     };
@@ -125,6 +126,33 @@ describe('ServerManagementService', () => {
       const status = await service.getServerStatus('myserver');
 
       expect(status).toBe('starting');
+    });
+  });
+
+  describe('findContainerId', () => {
+    it('should resolve container via docker compose first', async () => {
+      (fs.pathExists as jest.Mock).mockResolvedValue(true);
+      mockExec.mockResolvedValueOnce({ stdout: 'compose123\n', stderr: '' });
+
+      const containerId = await (service as any).findContainerId('myserver');
+
+      expect(containerId).toBe('compose123');
+      expect(mockExec).toHaveBeenCalledWith(
+        expect.stringContaining('docker compose ps -aq mc'),
+        expect.objectContaining({ cwd: '/app/servers/myserver' }),
+      );
+    });
+
+    it('should fallback to legacy exact name lookup when compose lookup fails', async () => {
+      (fs.pathExists as jest.Mock).mockResolvedValue(true);
+      mockExec
+        .mockRejectedValueOnce(new Error('compose unavailable'))
+        .mockResolvedValueOnce({ stdout: 'legacy123\n', stderr: '' });
+
+      const containerId = await (service as any).findContainerId('myserver');
+
+      expect(containerId).toBe('legacy123');
+      expect(mockExec).toHaveBeenCalledWith(expect.stringContaining('name=^/myserver$'));
     });
   });
 

--- a/backend/src/server-management/server-management.service.ts
+++ b/backend/src/server-management/server-management.service.ts
@@ -1,5 +1,6 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { exec } from 'node:child_process';
+import type { ExecOptions } from 'node:child_process';
 import { promisify } from 'node:util';
 import * as path from 'node:path';
 import * as fs from 'fs-extra';
@@ -16,13 +17,14 @@ const execAsync = promisify(exec);
 const DOCKER_COMMANDS = {
   COMPOSE_DOWN: 'docker compose down',
   COMPOSE_UP: 'docker compose up -d',
+  COMPOSE_PS_SERVICE: 'docker compose ps -aq mc',
   PS_FILTER: (serverId: string) => `docker ps -a --filter "name=^/${serverId}$" --format "{{.ID}}"`,
   PS_PARTIAL: (serverId: string) => `docker ps -a --filter "name=${serverId}" --format "{{.ID}}"`,
   INSPECT_STATUS: (containerId: string) => `docker inspect --format="{{.State.Status}}" ${containerId}`,
   STATS_CPU: (containerId: string) => `docker stats ${containerId} --no-stream --format "{{.CPUPerc}}"`,
   STATS_MEM: (containerId: string) => `docker stats ${containerId} --no-stream --format "{{.MemUsage}}"`,
   // Single command to get all running containers stats at once (much faster)
-  STATS_ALL: String.raw`docker stats --no-stream --format "{{.Name}}\t{{.CPUPerc}}\t{{.MemUsage}}"`,
+  STATS_ALL: String.raw`docker stats --no-stream --format "{{.Container}}\t{{.Name}}\t{{.CPUPerc}}\t{{.MemUsage}}"`,
   LOGS: (containerId: string, lines: number) => `docker logs --tail ${lines} --timestamps ${containerId} 2>&1`,
   LOGS_SINCE: (containerId: string, since: string) => `docker logs --since ${since} --timestamps ${containerId} 2>&1`,
   EXEC_RCON: (containerId: string, port: string, password: string, command: string) => {
@@ -78,6 +80,7 @@ export class ServerManagementService {
   private readonly logger = new Logger(ServerManagementService.name);
   private readonly SERVERS_DIR: string;
   private readonly BASE_DIR: string;
+  private readonly COMPOSE_PROJECT?: string;
 
   constructor(
     private readonly configService: ConfigService,
@@ -87,6 +90,7 @@ export class ServerManagementService {
   ) {
     this.SERVERS_DIR = this.configService.get('serversDir');
     this.BASE_DIR = this.configService.get('baseDir');
+    this.COMPOSE_PROJECT = this.configService.get<string>('composeProject')?.trim() || undefined;
     fs.ensureDirSync(this.SERVERS_DIR);
   }
 
@@ -104,6 +108,32 @@ export class ServerManagementService {
 
   private getMcDataPath(serverId: string): string {
     return path.join(this.SERVERS_DIR, serverId, 'mc-data');
+  }
+
+  private getComposeProjectName(serverId: string): string | undefined {
+    if (!this.COMPOSE_PROJECT) return undefined;
+    return `${this.COMPOSE_PROJECT}_${serverId}`;
+  }
+
+  private getComposeExecOptions(serverId: string): ExecOptions {
+    const composeDir = path.dirname(this.getDockerComposePath(serverId));
+    const composeProjectName = this.getComposeProjectName(serverId);
+
+    if (!composeProjectName) {
+      return { cwd: composeDir };
+    }
+
+    return {
+      cwd: composeDir,
+      env: {
+        ...process.env,
+        COMPOSE_PROJECT_NAME: composeProjectName,
+      },
+    };
+  }
+
+  private async execComposeCommand(serverId: string, command: string) {
+    return execAsync(command, this.getComposeExecOptions(serverId));
   }
 
   private async getUserSettings(): Promise<{
@@ -243,6 +273,27 @@ export class ServerManagementService {
       throw new Error(`Invalid server ID: ${serverId}`);
     }
 
+    const dockerComposePath = this.getDockerComposePath(serverId);
+    if (await fs.pathExists(dockerComposePath)) {
+      try {
+        const { stdout } = await this.execComposeCommand(serverId, DOCKER_COMMANDS.COMPOSE_PS_SERVICE);
+        const composeContainerIds = stdout
+          .toString()
+          .trim()
+          .split('\n')
+          .filter((id) => id.trim());
+
+        if (composeContainerIds.length > 0) {
+          if (composeContainerIds.length > 1) {
+            this.logger.warn(`Multiple compose containers found for server "${serverId}". Using first: ${composeContainerIds[0]}`);
+          }
+          return composeContainerIds[0];
+        }
+      } catch (error) {
+        this.logger.warn(`Could not resolve compose container for server ${serverId}, using legacy fallback`, error);
+      }
+    }
+
     const { stdout } = await execAsync(DOCKER_COMMANDS.PS_FILTER(serverId));
     if (stdout.trim()) {
       const containerIds = stdout
@@ -272,9 +323,8 @@ export class ServerManagementService {
         return false;
       }
 
-      const composeDir = path.dirname(dockerComposePath);
-      await execAsync(DOCKER_COMMANDS.COMPOSE_DOWN, { cwd: composeDir });
-      await execAsync(DOCKER_COMMANDS.COMPOSE_UP, { cwd: composeDir });
+      await this.execComposeCommand(serverId, DOCKER_COMMANDS.COMPOSE_DOWN);
+      await this.execComposeCommand(serverId, DOCKER_COMMANDS.COMPOSE_UP);
 
       this.logger.log(`Server ${serverId} restarted successfully`);
       await this.sendDiscordNotification('restarted', serverId);
@@ -298,8 +348,7 @@ export class ServerManagementService {
       const dockerComposePath = this.getDockerComposePath(serverId);
 
       if (await fs.pathExists(dockerComposePath)) {
-        const composeDir = path.dirname(dockerComposePath);
-        await execAsync(DOCKER_COMMANDS.COMPOSE_DOWN, { cwd: composeDir });
+        await this.execComposeCommand(serverId, DOCKER_COMMANDS.COMPOSE_DOWN);
       }
 
       if (await fs.pathExists(serverDataDir)) {
@@ -435,7 +484,7 @@ export class ServerManagementService {
       return {
         exists: false,
         status: 'not_found',
-        error: error.message,
+        error: (error as Error).message,
       };
     }
   }
@@ -456,9 +505,8 @@ export class ServerManagementService {
       }
 
       if (await fs.pathExists(dockerComposePath)) {
-        const composeDir = path.dirname(dockerComposePath);
         try {
-          await execAsync(DOCKER_COMMANDS.COMPOSE_DOWN, { cwd: composeDir });
+          await this.execComposeCommand(serverId, DOCKER_COMMANDS.COMPOSE_DOWN);
         } catch (error) {
           this.logger.warn(`Could not stop server ${serverId} before deletion`, error);
         }
@@ -575,10 +623,10 @@ export class ServerManagementService {
 
       // Get statuses and limits in parallel
       const serverDataPromises = validServers.map(async (serverId) => {
-        const [status, limits] = await Promise.all([this.getServerStatus(serverId), this.getServerLimits(serverId)]);
+        const [status, limits, containerId] = await Promise.all([this.getServerStatus(serverId), this.getServerLimits(serverId), this.findContainerId(serverId)]);
 
-        // Match container name - could be serverId or serverId-minecraft-1
-        const stats = allStats[serverId] || allStats[`${serverId}-minecraft-1`] || allStats[`${serverId}_minecraft_1`];
+        // Prefer exact container ID mapping, then fallback to legacy name patterns
+        const stats = allStats.byId[containerId] || allStats.byName[serverId] || allStats.byName[`${serverId}-minecraft-1`] || allStats.byName[`${serverId}_minecraft_1`];
 
         if (status !== 'running' || !stats) {
           return {
@@ -622,10 +670,14 @@ export class ServerManagementService {
   }
 
   // Get stats for ALL running containers in a single docker command
-  private async getAllContainersStats(): Promise<Record<string, { cpuUsage: string; memoryUsage: string; memoryLimit: string }>> {
+  private async getAllContainersStats(): Promise<{
+    byId: Record<string, { cpuUsage: string; memoryUsage: string; memoryLimit: string }>;
+    byName: Record<string, { cpuUsage: string; memoryUsage: string; memoryLimit: string }>;
+  }> {
     try {
       const { stdout } = await execAsync(DOCKER_COMMANDS.STATS_ALL);
-      const stats: Record<string, { cpuUsage: string; memoryUsage: string; memoryLimit: string }> = {};
+      const statsById: Record<string, { cpuUsage: string; memoryUsage: string; memoryLimit: string }> = {};
+      const statsByName: Record<string, { cpuUsage: string; memoryUsage: string; memoryLimit: string }> = {};
 
       const lines = stdout
         .trim()
@@ -633,24 +685,27 @@ export class ServerManagementService {
         .filter((line) => line.trim());
       for (const line of lines) {
         const parts = line.split('\t');
-        if (parts.length >= 3) {
-          const name = parts[0].trim();
-          const cpuUsage = parts[1].trim();
-          const memUsage = parts[2].trim();
+        if (parts.length >= 4) {
+          const containerId = parts[0].trim();
+          const name = parts[1].trim();
+          const cpuUsage = parts[2].trim();
+          const memUsage = parts[3].trim();
           const memoryParts = memUsage.split(' / ');
 
-          stats[name] = {
+          const parsedStats = {
             cpuUsage,
             memoryUsage: memoryParts[0] || 'N/A',
             memoryLimit: memoryParts[1] || 'N/A',
           };
+          statsById[containerId] = parsedStats;
+          statsByName[name] = parsedStats;
         }
       }
 
-      return stats;
+      return { byId: statsById, byName: statsByName };
     } catch (error) {
       this.logger.warn('Failed to get all containers stats:', error);
-      return {};
+      return { byId: {}, byName: {} };
     }
   }
 
@@ -714,7 +769,7 @@ export class ServerManagementService {
     } catch (error) {
       this.logger.error(`Failed to get logs for server ${serverId}`, error);
       return {
-        logs: `Error retrieving logs: ${error.message}`,
+        logs: `Error retrieving logs: ${(error as Error).message}`,
         hasErrors: true,
         lastUpdate: new Date(),
         status: 'not_found',
@@ -832,7 +887,7 @@ export class ServerManagementService {
     } catch (error) {
       console.error(`Failed to get logs stream for server ${serverId}:`, error);
       return {
-        logs: `Error retrieving logs: ${error.message}`,
+        logs: `Error retrieving logs: ${(error as Error).message}`,
         hasErrors: true,
         lastUpdate: new Date(),
         status: 'not_found',
@@ -889,7 +944,7 @@ export class ServerManagementService {
     } catch (error) {
       this.logger.error(`Failed to get logs since ${timestamp} for server ${serverId}`, error);
       return {
-        logs: `Error retrieving logs: ${error.message}`,
+        logs: `Error retrieving logs: ${(error as Error).message}`,
         hasErrors: true,
         lastUpdate: new Date(),
         status: 'not_found',
@@ -941,7 +996,7 @@ export class ServerManagementService {
       return { success: true, output: stdout || 'Command executed successfully' };
     } catch (error) {
       this.logger.error(`Error executing command on server ${serverId}`, error);
-      return { success: false, output: `Error: ${error.message}` };
+      return { success: false, output: `Error: ${(error as Error).message}` };
     }
   }
 
@@ -972,13 +1027,11 @@ export class ServerManagementService {
         await this.fixBedrockPermissions(serverId);
       }
 
-      const composeDir = path.dirname(dockerComposePath);
-
       if ((await this.getServerStatus(serverId)) !== 'not_found') {
-        await execAsync(DOCKER_COMMANDS.COMPOSE_DOWN, { cwd: composeDir });
+        await this.execComposeCommand(serverId, DOCKER_COMMANDS.COMPOSE_DOWN);
       }
 
-      await execAsync(DOCKER_COMMANDS.COMPOSE_UP, { cwd: composeDir });
+      await this.execComposeCommand(serverId, DOCKER_COMMANDS.COMPOSE_UP);
 
       this.logger.log(`Server ${serverId} started successfully`);
       await this.sendDiscordNotification('started', serverId);
@@ -1020,7 +1073,7 @@ export class ServerManagementService {
       await execAsync(DOCKER_COMMANDS.FIX_PERMISSIONS(hostMcDataPath, uid, gid));
       this.logger.log(`Permissions fixed for ${serverId}`);
     } catch (error) {
-      this.logger.warn(`Could not fix permissions for ${serverId}: ${error.message}`);
+      this.logger.warn(`Could not fix permissions for ${serverId}: ${(error as Error).message}`);
       // Continue anyway - might work if permissions are already correct
     }
   }
@@ -1038,8 +1091,7 @@ export class ServerManagementService {
         return false;
       }
 
-      const composeDir = path.dirname(dockerComposePath);
-      await execAsync(DOCKER_COMMANDS.COMPOSE_DOWN, { cwd: composeDir });
+      await this.execComposeCommand(serverId, DOCKER_COMMANDS.COMPOSE_DOWN);
 
       this.logger.log(`Server ${serverId} stopped successfully`);
       await this.sendDiscordNotification('stopped', serverId);

--- a/config.json
+++ b/config.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.9.4",
+  "version": "1.9.5",
   "description": "Minecraft Docker Manager - Control panel for managing Minecraft servers via Docker",
   "author": "ketbome",
   "license": "MIT"

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -28,6 +28,7 @@ All variables can be set in `.env` or `docker-compose.yml`.
 | `FRONTEND_PORT` | `3000`  | Web UI port               |
 | `BACKEND_PORT`  | `8091`  | API port                  |
 | `BASE_DIR`      | `$PWD`  | Base path for server data |
+| `COMPOSE_PROJECT` | _(empty)_ | Optional prefix for per-server Docker Compose project names (`<prefix>_<serverId>`) |
 
 ### Authentication
 

--- a/docker-compose.development.yml
+++ b/docker-compose.development.yml
@@ -13,6 +13,7 @@ services:
       - CLIENT_USERNAME=${CLIENT_USERNAME:-admin}
       - ALLOW_INSECURE_AUTH_COOKIES=${ALLOW_INSECURE_AUTH_COOKIES:-false}
       - BASE_DIR=${BASE_DIR:-$PWD}
+      - COMPOSE_PROJECT=${COMPOSE_PROJECT:-}
       # - BASE_PATH=${BASE_PATH}  # Subdirectory routing (e.g., /api)
     volumes:
       - ${BASE_DIR:-$PWD}/servers:/app/servers

--- a/docker-compose.single.yml
+++ b/docker-compose.single.yml
@@ -13,6 +13,7 @@ services:
       - CLIENT_USERNAME=${CLIENT_USERNAME:-admin}
       - ALLOW_INSECURE_AUTH_COOKIES=${ALLOW_INSECURE_AUTH_COOKIES:-false}
       - BASE_DIR=${BASE_DIR:-$PWD}
+      - COMPOSE_PROJECT=${COMPOSE_PROJECT:-}
 
       # Frontend Configuration (loaded at runtime)
       - NEXT_PUBLIC_BACKEND_URL=${NEXT_PUBLIC_BACKEND_URL:-http://localhost:8091}

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -22,6 +22,7 @@ services:
       - CLIENT_USERNAME=${CLIENT_USERNAME:-admin}
       - ALLOW_INSECURE_AUTH_COOKIES=${ALLOW_INSECURE_AUTH_COOKIES:-false}
       - BASE_DIR=${BASE_DIR:-$PWD}
+      - COMPOSE_PROJECT=${COMPOSE_PROJECT:-}
     volumes:
       - ${BASE_DIR:-$PWD}/servers:/app/servers
       - /var/run/docker.sock:/var/run/docker.sock

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,7 @@ services:
       - CLIENT_USERNAME=${CLIENT_USERNAME:-admin}
       - ALLOW_INSECURE_AUTH_COOKIES=${ALLOW_INSECURE_AUTH_COOKIES:-false}
       - BASE_DIR=${BASE_DIR:-$PWD}
+      - COMPOSE_PROJECT=${COMPOSE_PROJECT:-}
       # - BASE_PATH=${BASE_PATH}  # Subdirectory routing (e.g., /api)
     volumes:
       - ${BASE_DIR:-$PWD}/servers:/app/servers

--- a/env.example
+++ b/env.example
@@ -18,6 +18,7 @@ ALLOW_INSECURE_AUTH_COOKIES=false             # Set true only for HTTP/LAN setup
 # Directories
 # -----------------------------------------------------------------------------
 BASE_DIR=$PWD                                  # Base directory on host (required for Docker socket)
+COMPOSE_PROJECT=                               # Optional prefix for server compose project names (final name: <prefix>_<serverId>)
 
 # -----------------------------------------------------------------------------
 # URLs (Important for remote access and CORS)


### PR DESCRIPTION
## Description

Implementa soporte opcional para `COMPOSE_PROJECT` en backend para que los contenedores Minecraft usen prefijo de proyecto (`<COMPOSE_PROJECT>_<serverId>`) en lugar de depender de `container_name` fijo en `mc`.  
Se mantiene retrocompatibilidad para servidores existentes mediante fallback de resolución de contenedor.

También se agregó alias de red estable (`serverId`) en modo proxy para no romper resolución de `mc-router`.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 📝 Documentation update
- [x] 🔧 Configuration change
- [ ] ♻️ Refactoring (no functional changes)
- [x] 🧪 Tests

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have tested my changes locally
- [x] I have updated documentation if needed
- [x] My changes don't introduce new warnings or errors

## Screenshots (if applicable)

N/A (no UI changes)

## Related Issues

Closes #<issue-number>