### PR TITLE
feat(settings): add global Java defaults for new server creation

### DIFF
--- a/backend/src/server-management/server-management.controller.spec.ts
+++ b/backend/src/server-management/server-management.controller.spec.ts
@@ -162,4 +162,58 @@ describe('ServerManagementController', () => {
       expect(result).toEqual(mockLogs);
     });
   });
+
+  describe('createServer', () => {
+    const mockReq = { user: { userId: 1 } };
+
+    it('should apply global java defaults when creating JAVA server', async () => {
+      settingsService.getSettings.mockResolvedValue({
+        preferences: {
+          proxyEnabled: false,
+          proxyBaseDomain: null,
+          javaServerDefaults: {
+            onlineMode: false,
+            maxMemory: '3G',
+            cpuLimit: '1',
+            ignoredField: 'ignored',
+          },
+        },
+      } as any);
+      dockerComposeService.createServer.mockResolvedValue({ id: 'demo' } as any);
+
+      await controller.createServer(mockReq, { id: 'demo', edition: 'JAVA', maxMemory: '4G' } as any);
+
+      expect(dockerComposeService.createServer).toHaveBeenCalledWith(
+        'demo',
+        expect.objectContaining({
+          id: 'demo',
+          edition: 'JAVA',
+          onlineMode: false,
+          maxMemory: '4G',
+          cpuLimit: '1',
+        }),
+        false,
+      );
+      const javaPayload = dockerComposeService.createServer.mock.calls[0][1] as Record<string, unknown>;
+      expect(javaPayload.ignoredField).toBeUndefined();
+    });
+
+    it('should not apply java defaults for BEDROCK server', async () => {
+      settingsService.getSettings.mockResolvedValue({
+        preferences: {
+          proxyEnabled: false,
+          proxyBaseDomain: null,
+          javaServerDefaults: {
+            onlineMode: false,
+          },
+        },
+      } as any);
+      dockerComposeService.createServer.mockResolvedValue({ id: 'bedrock-1' } as any);
+
+      await controller.createServer(mockReq, { id: 'bedrock-1', edition: 'BEDROCK' } as any);
+
+      const bedrockPayload = dockerComposeService.createServer.mock.calls[0][1] as Record<string, unknown>;
+      expect(bedrockPayload.onlineMode).toBeUndefined();
+    });
+  });
 });

--- a/backend/src/server-management/server-management.controller.ts
+++ b/backend/src/server-management/server-management.controller.ts
@@ -9,6 +9,28 @@ import { PayloadToken } from 'src/auth/models/token.model';
 import { ProxyService } from 'src/proxy/proxy.service';
 import { ExecuteCommandDto } from './dto/execute-command.dto';
 
+const JAVA_SERVER_DEFAULT_KEYS = new Set([
+  'onlineMode',
+  'maxPlayers',
+  'initMemory',
+  'maxMemory',
+  'cpuLimit',
+  'cpuReservation',
+  'memoryReservation',
+  'difficulty',
+  'gameMode',
+  'pvp',
+  'allowFlight',
+  'commandBlock',
+  'viewDistance',
+  'simulationDistance',
+  'enableAutoStop',
+  'autoStopTimeoutEst',
+  'enableAutoPause',
+  'autoPauseTimeoutEst',
+  'enableBackup',
+]);
+
 @Controller('servers')
 @UseGuards(JwtAuthGuard)
 export class ServerManagementController {
@@ -18,6 +40,19 @@ export class ServerManagementController {
     private readonly settingsService: SettingsService,
     private readonly proxyService: ProxyService,
   ) {}
+
+  private sanitizeJavaServerDefaults(defaults: Record<string, any> | undefined): Record<string, any> {
+    if (!defaults || typeof defaults !== 'object') {
+      return {};
+    }
+
+    return Object.entries(defaults).reduce((acc, [key, value]) => {
+      if (JAVA_SERVER_DEFAULT_KEYS.has(key) && value !== undefined) {
+        acc[key] = value;
+      }
+      return acc;
+    }, {} as Record<string, any>);
+  }
 
   @Get()
   async getAllServers(): Promise<ServerListItemDto[]> {
@@ -65,8 +100,17 @@ export class ServerManagementController {
 
       const proxyEnabled = settings.preferences?.proxyEnabled && !!settings.preferences?.proxyBaseDomain;
       const baseDomain = settings.preferences?.proxyBaseDomain;
+      const javaServerDefaults =
+        (data.edition ?? 'JAVA') === 'JAVA'
+          ? this.sanitizeJavaServerDefaults(settings.preferences?.javaServerDefaults)
+          : {};
 
-      const serverConfig = await this.dockerComposeService.createServer(id, data, proxyEnabled);
+      const createPayload = {
+        ...javaServerDefaults,
+        ...data,
+      };
+
+      const serverConfig = await this.dockerComposeService.createServer(id, createPayload, proxyEnabled);
 
       // Regenerate routes.json if proxy is enabled (Java only, mc-router doesn't support Bedrock)
       if (proxyEnabled && baseDomain) {

--- a/backend/src/users/controllers/settings.controller.ts
+++ b/backend/src/users/controllers/settings.controller.ts
@@ -22,6 +22,7 @@ export class SettingsController {
       ...settings,
       proxy,
       network,
+      javaServerDefaults: settings.preferences?.javaServerDefaults ?? null,
     };
   }
 

--- a/backend/src/users/dtos/settings.dto.ts
+++ b/backend/src/users/dtos/settings.dto.ts
@@ -1,4 +1,4 @@
-import { IsOptional, IsString, IsBoolean, ValidateNested } from 'class-validator';
+import { IsOptional, IsString, IsBoolean, IsEnum, ValidateNested } from 'class-validator';
 import { Type } from 'class-transformer';
 
 export class ProxySettingsDto {
@@ -19,6 +19,84 @@ export class NetworkSettingsDto {
   @IsOptional()
   @IsString()
   lanIp?: string;
+}
+
+export class JavaServerDefaultsDto {
+  @IsOptional()
+  @IsBoolean()
+  onlineMode?: boolean;
+
+  @IsOptional()
+  @IsString()
+  maxPlayers?: string;
+
+  @IsOptional()
+  @IsString()
+  initMemory?: string;
+
+  @IsOptional()
+  @IsString()
+  maxMemory?: string;
+
+  @IsOptional()
+  @IsString()
+  cpuLimit?: string;
+
+  @IsOptional()
+  @IsString()
+  cpuReservation?: string;
+
+  @IsOptional()
+  @IsString()
+  memoryReservation?: string;
+
+  @IsOptional()
+  @IsEnum(['peaceful', 'easy', 'normal', 'hard'])
+  difficulty?: 'peaceful' | 'easy' | 'normal' | 'hard';
+
+  @IsOptional()
+  @IsEnum(['survival', 'creative', 'adventure', 'spectator'])
+  gameMode?: 'survival' | 'creative' | 'adventure' | 'spectator';
+
+  @IsOptional()
+  @IsBoolean()
+  pvp?: boolean;
+
+  @IsOptional()
+  @IsBoolean()
+  allowFlight?: boolean;
+
+  @IsOptional()
+  @IsBoolean()
+  commandBlock?: boolean;
+
+  @IsOptional()
+  @IsString()
+  viewDistance?: string;
+
+  @IsOptional()
+  @IsString()
+  simulationDistance?: string;
+
+  @IsOptional()
+  @IsBoolean()
+  enableAutoStop?: boolean;
+
+  @IsOptional()
+  @IsString()
+  autoStopTimeoutEst?: string;
+
+  @IsOptional()
+  @IsBoolean()
+  enableAutoPause?: boolean;
+
+  @IsOptional()
+  @IsString()
+  autoPauseTimeoutEst?: string;
+
+  @IsOptional()
+  @IsBoolean()
+  enableBackup?: boolean;
 }
 
 export class UpdateSettingsDto {
@@ -46,6 +124,11 @@ export class UpdateSettingsDto {
   @ValidateNested()
   @Type(() => NetworkSettingsDto)
   network?: NetworkSettingsDto;
+
+  @IsOptional()
+  @ValidateNested()
+  @Type(() => JavaServerDefaultsDto)
+  javaServerDefaults?: JavaServerDefaultsDto;
 }
 
 export class SettingsResponseDto {
@@ -62,4 +145,5 @@ export class SettingsResponseDto {
     publicIp: string | null;
     lanIp: string | null;
   };
+  javaServerDefaults?: JavaServerDefaultsDto | null;
 }

--- a/backend/src/users/services/settings.service.ts
+++ b/backend/src/users/services/settings.service.ts
@@ -7,6 +7,28 @@ import { UsersService } from 'src/users/services/users.service';
 
 @Injectable()
 export class SettingsService {
+  private readonly javaDefaultsKeys = new Set([
+    'onlineMode',
+    'maxPlayers',
+    'initMemory',
+    'maxMemory',
+    'cpuLimit',
+    'cpuReservation',
+    'memoryReservation',
+    'difficulty',
+    'gameMode',
+    'pvp',
+    'allowFlight',
+    'commandBlock',
+    'viewDistance',
+    'simulationDistance',
+    'enableAutoStop',
+    'autoStopTimeoutEst',
+    'enableAutoPause',
+    'autoPauseTimeoutEst',
+    'enableBackup',
+  ]);
+
   constructor(
     @InjectRepository(Settings)
     private readonly settingsRepo: Repository<Settings>,
@@ -63,8 +85,25 @@ export class SettingsService {
       delete (dto as any).network;
     }
 
+    if (dto.javaServerDefaults) {
+      settings.preferences = {
+        ...settings.preferences,
+        javaServerDefaults: this.sanitizeJavaServerDefaults(dto.javaServerDefaults),
+      };
+      delete (dto as any).javaServerDefaults;
+    }
+
     Object.assign(settings, dto);
     return this.settingsRepo.save(settings);
+  }
+
+  private sanitizeJavaServerDefaults(defaults: Record<string, any>): Record<string, any> {
+    return Object.entries(defaults).reduce((acc, [key, value]) => {
+      if (this.javaDefaultsKeys.has(key) && value !== undefined) {
+        acc[key] = value;
+      }
+      return acc;
+    }, {} as Record<string, any>);
   }
 
   async getProxySettings(userId: number): Promise<{ enabled: boolean; baseDomain: string | null; available: boolean }> {

--- a/config.json
+++ b/config.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.9.5",
+  "version": "1.9.6",
   "description": "Minecraft Docker Manager - Control panel for managing Minecraft servers via Docker",
   "author": "ketbome",
   "license": "MIT"

--- a/doc/features.md
+++ b/doc/features.md
@@ -30,6 +30,7 @@ flowchart LR
 | All server types | Vanilla, Paper, Forge, Neoforge, Fabric, Purpur, CurseForge modpacks |
 | Any version      | 1.8 to latest, snapshots included                                    |
 | Templates        | Pre-configured: Survival, Creative, SkyBlock, PvP, etc.              |
+| Java defaults    | Global defaults for new Java servers (offline mode, resources, backup switch) |
 | Resource limits  | Set RAM, CPU per server                                              |
 
 ## Real-time Monitoring

--- a/frontend/src/app/dashboard/settings/page.tsx
+++ b/frontend/src/app/dashboard/settings/page.tsx
@@ -29,6 +29,7 @@ import {
   EyeOff,
   Network,
   Info,
+  SlidersHorizontal,
 } from 'lucide-react';
 import { Switch } from '@/components/ui/switch';
 import { useLanguage } from '@/lib/hooks/useLanguage';
@@ -37,6 +38,7 @@ import {
   updateSettings,
   testDiscordWebhook,
   UserSettings,
+  JavaServerDefaults,
   ProxySettings,
   NetworkSettings,
 } from '@/services/settings/settings.service';
@@ -77,6 +79,18 @@ export default function SettingsPage() {
   });
   const [publicIp, setPublicIp] = useState('');
   const [lanIp, setLanIp] = useState('');
+  const [javaDefaults, setJavaDefaults] = useState<JavaServerDefaults>({
+    onlineMode: true,
+    maxPlayers: '',
+    initMemory: '',
+    maxMemory: '',
+    cpuLimit: '',
+    cpuReservation: '',
+    memoryReservation: '',
+    viewDistance: '',
+    simulationDistance: '',
+    enableBackup: false,
+  });
 
   const form = useForm<UserSettings>({
     defaultValues: {
@@ -109,6 +123,9 @@ export default function SettingsPage() {
           setPublicIp(settings.network.publicIp || '');
           setLanIp(settings.network.lanIp || '');
         }
+        if (settings.javaServerDefaults) {
+          setJavaDefaults(settings.javaServerDefaults);
+        }
       } catch (error) {
         console.error('Error loading settings:', error);
         mcToast.error(t('errorLoadingServerInfo'));
@@ -136,6 +153,19 @@ export default function SettingsPage() {
         network: {
           publicIp: publicIp || undefined,
           lanIp: lanIp || undefined,
+        },
+        javaServerDefaults: {
+          ...javaDefaults,
+          maxPlayers: javaDefaults.maxPlayers || undefined,
+          initMemory: javaDefaults.initMemory || undefined,
+          maxMemory: javaDefaults.maxMemory || undefined,
+          cpuLimit: javaDefaults.cpuLimit || undefined,
+          cpuReservation: javaDefaults.cpuReservation || undefined,
+          memoryReservation: javaDefaults.memoryReservation || undefined,
+          viewDistance: javaDefaults.viewDistance || undefined,
+          simulationDistance: javaDefaults.simulationDistance || undefined,
+          autoStopTimeoutEst: javaDefaults.autoStopTimeoutEst || undefined,
+          autoPauseTimeoutEst: javaDefaults.autoPauseTimeoutEst || undefined,
         },
       };
       await updateSettings(updateData);
@@ -659,6 +689,163 @@ export default function SettingsPage() {
           </div>
 
           <div className="animate-fade-in-up stagger-8">
+            <Card className="border-2 border-gray-700/60 bg-gray-900/80 backdrop-blur-md shadow-xl">
+              <CardHeader>
+                <div className="flex items-center gap-3">
+                  <div className="w-10 h-10 rounded-lg bg-emerald-600/20 flex items-center justify-center">
+                    <SlidersHorizontal className="w-5 h-5 text-emerald-400" />
+                  </div>
+                  <div>
+                    <CardTitle className="text-white font-minecraft">
+                      {t('javaServerDefaultsTitle')}
+                    </CardTitle>
+                    <CardDescription className="text-gray-400">
+                      {t('javaServerDefaultsDesc')}
+                    </CardDescription>
+                  </div>
+                </div>
+              </CardHeader>
+              <CardContent className="space-y-4">
+                <div className="grid gap-4 sm:grid-cols-2">
+                  <div className="space-y-2">
+                    <Label htmlFor="javaDefaultsMaxPlayers" className="text-gray-200">
+                      {t('maxPlayers')}
+                    </Label>
+                    <Input
+                      id="javaDefaultsMaxPlayers"
+                      value={javaDefaults.maxPlayers || ''}
+                      onChange={(e) => setJavaDefaults({ ...javaDefaults, maxPlayers: e.target.value })}
+                      placeholder="10"
+                      className="bg-gray-800 border-gray-700 text-white"
+                    />
+                  </div>
+                  <div className="space-y-2">
+                    <Label htmlFor="javaDefaultsInitMemory" className="text-gray-200">
+                      {t('initialMemoryJvm')}
+                    </Label>
+                    <Input
+                      id="javaDefaultsInitMemory"
+                      value={javaDefaults.initMemory || ''}
+                      onChange={(e) => setJavaDefaults({ ...javaDefaults, initMemory: e.target.value })}
+                      placeholder="2G"
+                      className="bg-gray-800 border-gray-700 text-white"
+                    />
+                  </div>
+                  <div className="space-y-2">
+                    <Label htmlFor="javaDefaultsMaxMemory" className="text-gray-200">
+                      {t('maxMemoryJvm')}
+                    </Label>
+                    <Input
+                      id="javaDefaultsMaxMemory"
+                      value={javaDefaults.maxMemory || ''}
+                      onChange={(e) => setJavaDefaults({ ...javaDefaults, maxMemory: e.target.value })}
+                      placeholder="4G"
+                      className="bg-gray-800 border-gray-700 text-white"
+                    />
+                  </div>
+                  <div className="space-y-2">
+                    <Label htmlFor="javaDefaultsCpuLimit" className="text-gray-200">
+                      {t('cpuLimit')}
+                    </Label>
+                    <Input
+                      id="javaDefaultsCpuLimit"
+                      value={javaDefaults.cpuLimit || ''}
+                      onChange={(e) => setJavaDefaults({ ...javaDefaults, cpuLimit: e.target.value })}
+                      placeholder="1"
+                      className="bg-gray-800 border-gray-700 text-white"
+                    />
+                  </div>
+                  <div className="space-y-2">
+                    <Label htmlFor="javaDefaultsCpuReservation" className="text-gray-200">
+                      {t('cpuReservation')}
+                    </Label>
+                    <Input
+                      id="javaDefaultsCpuReservation"
+                      value={javaDefaults.cpuReservation || ''}
+                      onChange={(e) =>
+                        setJavaDefaults({ ...javaDefaults, cpuReservation: e.target.value })
+                      }
+                      placeholder="0.25"
+                      className="bg-gray-800 border-gray-700 text-white"
+                    />
+                  </div>
+                  <div className="space-y-2">
+                    <Label htmlFor="javaDefaultsMemoryReservation" className="text-gray-200">
+                      {t('memoryReservationDocker')}
+                    </Label>
+                    <Input
+                      id="javaDefaultsMemoryReservation"
+                      value={javaDefaults.memoryReservation || ''}
+                      onChange={(e) =>
+                        setJavaDefaults({ ...javaDefaults, memoryReservation: e.target.value })
+                      }
+                      placeholder="2G"
+                      className="bg-gray-800 border-gray-700 text-white"
+                    />
+                  </div>
+                  <div className="space-y-2">
+                    <Label htmlFor="javaDefaultsViewDistance" className="text-gray-200">
+                      {t('viewDistance')}
+                    </Label>
+                    <Input
+                      id="javaDefaultsViewDistance"
+                      value={javaDefaults.viewDistance || ''}
+                      onChange={(e) => setJavaDefaults({ ...javaDefaults, viewDistance: e.target.value })}
+                      placeholder="6"
+                      className="bg-gray-800 border-gray-700 text-white"
+                    />
+                  </div>
+                  <div className="space-y-2">
+                    <Label htmlFor="javaDefaultsSimulationDistance" className="text-gray-200">
+                      {t('simulationDistance')}
+                    </Label>
+                    <Input
+                      id="javaDefaultsSimulationDistance"
+                      value={javaDefaults.simulationDistance || ''}
+                      onChange={(e) =>
+                        setJavaDefaults({ ...javaDefaults, simulationDistance: e.target.value })
+                      }
+                      placeholder="4"
+                      className="bg-gray-800 border-gray-700 text-white"
+                    />
+                  </div>
+                </div>
+
+                <div className="flex items-center justify-between pt-2">
+                  <div>
+                    <p className="text-sm font-medium text-gray-200">{t('onlineMode')}</p>
+                    <p className="text-xs text-gray-500">{t('javaServerDefaultsOnlineModeDesc')}</p>
+                  </div>
+                  <Switch
+                    checked={javaDefaults.onlineMode !== false}
+                    onCheckedChange={(checked) =>
+                      setJavaDefaults({ ...javaDefaults, onlineMode: checked })
+                    }
+                  />
+                </div>
+
+                <div className="flex items-center justify-between">
+                  <div>
+                    <p className="text-sm font-medium text-gray-200">{t('enableBackup')}</p>
+                    <p className="text-xs text-gray-500">{t('javaServerDefaultsBackupDesc')}</p>
+                  </div>
+                  <Switch
+                    checked={javaDefaults.enableBackup === true}
+                    onCheckedChange={(checked) =>
+                      setJavaDefaults({ ...javaDefaults, enableBackup: checked })
+                    }
+                  />
+                </div>
+
+                <div className="flex items-start gap-2 p-3 bg-emerald-900/20 border border-emerald-600/30 rounded-lg">
+                  <Info className="w-4 h-4 text-emerald-400 mt-0.5 shrink-0" />
+                  <p className="text-xs text-emerald-300">{t('javaServerDefaultsApplyOnlyNewServers')}</p>
+                </div>
+              </CardContent>
+            </Card>
+          </div>
+
+          <div className="animate-fade-in-up stagger-9">
             <Card className="border-2 border-red-600/40 bg-red-900/10 backdrop-blur-md shadow-xl">
               <CardHeader>
                 <div className="flex items-center gap-3">

--- a/frontend/src/lib/translations/de.ts
+++ b/frontend/src/lib/translations/de.ts
@@ -1306,6 +1306,13 @@ export const de: Record<TranslationKey, string> = {
   lanIpDesc: 'Deine lokale Netzwerk-IP. Für Spieler im gleichen Netzwerk',
   networkProxyNote:
     'Wenn Proxy aktiviert ist, wird der Proxy-Hostname anstelle von IP:Port in Benachrichtigungen verwendet',
+  javaServerDefaultsTitle: 'Java-Standardwerte für neue Server',
+  javaServerDefaultsDesc:
+    'Globale Standardwerte für die Erstellung neuer Java-Server (Vanilla und Modded).',
+  javaServerDefaultsOnlineModeDesc: 'Für Offline/Cracked-Umgebungen deaktivieren.',
+  javaServerDefaultsBackupDesc: 'Backups bei neuen Java-Servern automatisch aktivieren.',
+  javaServerDefaultsApplyOnlyNewServers:
+    'Diese Standardwerte gelten nur bei der Servererstellung. Bestehende Server werden nicht geändert.',
 
   // ===========================
   // BEDROCK EDITION

--- a/frontend/src/lib/translations/en.ts
+++ b/frontend/src/lib/translations/en.ts
@@ -1278,6 +1278,13 @@ export const en = {
   lanIpDesc: 'Your local network IP. For players on the same network',
   networkProxyNote:
     'When proxy is enabled, the proxy hostname will be used instead of IP:port in notifications',
+  javaServerDefaultsTitle: 'Java New Server Defaults',
+  javaServerDefaultsDesc:
+    'Global defaults applied when creating new Java servers (vanilla and modded).',
+  javaServerDefaultsOnlineModeDesc: 'Disable for offline/cracked mode environments.',
+  javaServerDefaultsBackupDesc: 'Automatically enable backups on new Java servers.',
+  javaServerDefaultsApplyOnlyNewServers:
+    'These defaults are only applied during server creation. Existing servers are not modified.',
 
   // ===========================
   // BEDROCK EDITION

--- a/frontend/src/lib/translations/es.ts
+++ b/frontend/src/lib/translations/es.ts
@@ -1300,6 +1300,13 @@ export const es: Record<TranslationKey, string> = {
   lanIpDesc: 'Tu IP de red local. Para jugadores en la misma red',
   networkProxyNote:
     'Cuando el proxy está habilitado, se usará el hostname del proxy en lugar de IP:puerto en las notificaciones',
+  javaServerDefaultsTitle: 'Defaults de Nuevos Servidores Java',
+  javaServerDefaultsDesc:
+    'Valores globales aplicados al crear nuevos servidores Java (vanilla y modded).',
+  javaServerDefaultsOnlineModeDesc: 'Desactiva para entornos offline/cracked.',
+  javaServerDefaultsBackupDesc: 'Activa backups automáticamente en nuevos servidores Java.',
+  javaServerDefaultsApplyOnlyNewServers:
+    'Estos defaults solo se aplican durante la creación. Los servidores existentes no se modifican.',
 
   // ===========================
   // BEDROCK EDITION

--- a/frontend/src/lib/translations/nl.ts
+++ b/frontend/src/lib/translations/nl.ts
@@ -1311,6 +1311,13 @@ export const nl: Record<TranslationKey, string> = {
   lanIpDesc: 'Je lokale netwerk IP. Voor spelers op hetzelfde netwerk',
   networkProxyNote:
     'Wanneer proxy is ingeschakeld, wordt de proxy hostnaam gebruikt in plaats van IP:poort in meldingen',
+  javaServerDefaultsTitle: 'Java standaardinstellingen voor nieuwe servers',
+  javaServerDefaultsDesc:
+    'Globale standaardwaarden bij het maken van nieuwe Java-servers (vanilla en modded).',
+  javaServerDefaultsOnlineModeDesc: 'Uitschakelen voor offline/cracked omgevingen.',
+  javaServerDefaultsBackupDesc: 'Back-ups automatisch inschakelen voor nieuwe Java-servers.',
+  javaServerDefaultsApplyOnlyNewServers:
+    'Deze standaardwaarden gelden alleen bij het aanmaken. Bestaande servers worden niet aangepast.',
 
   // ===========================
   // BEDROCK EDITION

--- a/frontend/src/lib/translations/pl.ts
+++ b/frontend/src/lib/translations/pl.ts
@@ -1284,6 +1284,13 @@ export const pl: Record<TranslationKey, string> = {
   lanIpDesc: 'Adres IP Twojej sieci lokalnej. Dla graczy w tej samej sieci',
   networkProxyNote:
     'Gdy proxy jest włączone, w powiadomieniach zamiast IP:port będzie używana nazwa hosta proxy',
+  javaServerDefaultsTitle: 'Domyślne ustawienia nowych serwerów Java',
+  javaServerDefaultsDesc:
+    'Globalne ustawienia stosowane podczas tworzenia nowych serwerów Java (vanilla i modded).',
+  javaServerDefaultsOnlineModeDesc: 'Wyłącz dla środowisk offline/cracked.',
+  javaServerDefaultsBackupDesc: 'Automatycznie włącz kopie zapasowe dla nowych serwerów Java.',
+  javaServerDefaultsApplyOnlyNewServers:
+    'Te ustawienia są stosowane tylko podczas tworzenia. Istniejące serwery nie są modyfikowane.',
 
   // ===========================
   // BEDROCK EDITION

--- a/frontend/src/services/minecraft-versions.service.ts
+++ b/frontend/src/services/minecraft-versions.service.ts
@@ -15,8 +15,11 @@ export interface VersionManifest {
 }
 
 let cachedVersions: MinecraftVersion[] | null = null;
+let cachedLatestRelease: string | null = null;
 let cacheTimestamp: number = 0;
 const CACHE_DURATION = 60 * 60 * 1000;
+
+const isValidJavaRelease = (id: string): boolean => /^1\.\d+(\.\d+)?$/.test(id);
 
 export const minecraftVersionsService = {
   async fetchVersions(): Promise<MinecraftVersion[]> {
@@ -33,6 +36,9 @@ export const minecraftVersionsService = {
       }
 
       const data: VersionManifest = await response.json();
+      cachedLatestRelease = data.latest?.release && isValidJavaRelease(data.latest.release)
+        ? data.latest.release
+        : null;
       cachedVersions = data.versions;
       cacheTimestamp = now;
 
@@ -46,12 +52,21 @@ export const minecraftVersionsService = {
 
   async getReleaseVersions(): Promise<MinecraftVersion[]> {
     const versions = await this.fetchVersions();
-    return versions.filter(v => v.type === 'release');
+    return versions.filter((v) => v.type === 'release' && isValidJavaRelease(v.id));
   },
 
   async getLatestRelease(): Promise<string> {
+    if (cachedLatestRelease) {
+      return cachedLatestRelease;
+    }
+
+    await this.fetchVersions();
+    if (cachedLatestRelease) {
+      return cachedLatestRelease;
+    }
+
     const versions = await this.getReleaseVersions();
-    return versions[0]?.id || '1.20.4';
+    return versions[0]?.id || '1.21';
   },
 
   async getVersionsByType(): Promise<{
@@ -105,6 +120,7 @@ export const minecraftVersionsService = {
 
   clearCache(): void {
     cachedVersions = null;
+    cachedLatestRelease = null;
     cacheTimestamp = 0;
   },
 
@@ -112,4 +128,3 @@ export const minecraftVersionsService = {
     return ['1.21', '1.20.6', '1.20.4', '1.19.4', '1.18.2', '1.16.5', '1.12.2'];
   }
 };
-

--- a/frontend/src/services/settings/settings.service.ts
+++ b/frontend/src/services/settings/settings.service.ts
@@ -11,12 +11,35 @@ export interface NetworkSettings {
   lanIp: string | null;
 }
 
+export interface JavaServerDefaults {
+  onlineMode?: boolean;
+  maxPlayers?: string;
+  initMemory?: string;
+  maxMemory?: string;
+  cpuLimit?: string;
+  cpuReservation?: string;
+  memoryReservation?: string;
+  difficulty?: 'peaceful' | 'easy' | 'normal' | 'hard';
+  gameMode?: 'survival' | 'creative' | 'adventure' | 'spectator';
+  pvp?: boolean;
+  allowFlight?: boolean;
+  commandBlock?: boolean;
+  viewDistance?: string;
+  simulationDistance?: string;
+  enableAutoStop?: boolean;
+  autoStopTimeoutEst?: string;
+  enableAutoPause?: boolean;
+  autoPauseTimeoutEst?: string;
+  enableBackup?: boolean;
+}
+
 export interface UserSettings {
   cfApiKey?: string;
   discordWebhook?: string;
   language?: 'en' | 'es';
   proxy?: ProxySettings;
   network?: NetworkSettings;
+  javaServerDefaults?: JavaServerDefaults | null;
 }
 
 export interface UpdateUserSettings {
@@ -31,6 +54,7 @@ export interface UpdateUserSettings {
     publicIp?: string;
     lanIp?: string;
   };
+  javaServerDefaults?: JavaServerDefaults;
 }
 
 export const getSettings = async (): Promise<UserSettings> => {


### PR DESCRIPTION
## Summary
- add global Java defaults in Settings and apply them only when creating new Java servers (including modded variants)
- include core default fields for resources/connectivity plus backup enable switch, with backend whitelist sanitization and controller tests
- improve Minecraft latest release resolution by using Mojang manifest `latest.release` and filtering invalid release ids
- bump project version in `config.json` to `1.9.6` and update features docs with Java defaults support

## Testing
- `cd backend && npm test -- server-management.controller.spec.ts docker-compose.service.spec.ts`
- `cd frontend && npm run lint`