### PR TITLE
feat: add GTNH server type and fix proxy backup behavior

### DIFF
--- a/backend/src/docker-compose/docker-compose.service.spec.ts
+++ b/backend/src/docker-compose/docker-compose.service.spec.ts
@@ -121,6 +121,19 @@ describe('DockerComposeService', () => {
       expect(parsed.services.mc.networks['minepanel-network'].aliases).toEqual(['proxyserver']);
     });
 
+    it('should attach backup service to proxy network when proxy is enabled', async () => {
+      const config = (service as any).createDefaultConfig('proxybackup');
+      config.enableBackup = true;
+
+      await service.generateDockerComposeFile(config, true);
+
+      const writeFileMock = fs.writeFile as unknown as jest.Mock;
+      const [, yamlContent] = writeFileMock.mock.calls[0];
+      const parsed = yaml.load(yamlContent as string) as any;
+
+      expect(parsed.services.backup.networks['minepanel-network']).toEqual({});
+    });
+
     it('should force restart policy to "no" when auto-stop is enabled', async () => {
       const config = (service as any).createDefaultConfig('autostop-server');
       config.enableAutoStop = true;

--- a/backend/src/docker-compose/docker-compose.service.ts
+++ b/backend/src/docker-compose/docker-compose.service.ts
@@ -1320,7 +1320,12 @@ export class DockerComposeService {
     if (config.enableSync === false) env.ENABLE_SYNC = 'false';
   }
 
-  private async addBackupService(dockerComposeConfig: any, config: ServerConfig, serverDir: string): Promise<void> {
+  private async addBackupService(
+    dockerComposeConfig: any,
+    config: ServerConfig,
+    serverDir: string,
+    useProxy: boolean,
+  ): Promise<void> {
     const backupEnv = this.buildBackupEnvironment(config);
     this.addOptionalBackupEnv(backupEnv, config);
 
@@ -1335,6 +1340,12 @@ export class DockerComposeService {
       volumes: [`${mcDataPath}:/data:ro`, `${backupsPath}:/backups`],
       restart: 'unless-stopped',
     };
+
+    if (useProxy) {
+      dockerComposeConfig.services.backup.networks = {
+        'minepanel-network': {},
+      };
+    }
 
     dockerComposeConfig.volumes.backups = {};
     await fs.ensureDir(path.join(serverDir, 'backups'));
@@ -1360,7 +1371,7 @@ export class DockerComposeService {
     const dockerComposeConfig = this.buildDockerComposeConfig(normalizedConfig, environment, volumes, availablePort, proxyEnabled, strategy);
 
     if (normalizedConfig.enableBackup) {
-      await this.addBackupService(dockerComposeConfig, normalizedConfig, serverDir);
+      await this.addBackupService(dockerComposeConfig, normalizedConfig, serverDir, useProxy);
     }
 
     let yamlContent = yaml.dump(dockerComposeConfig);

--- a/backend/src/docker-compose/docker-compose.service.ts
+++ b/backend/src/docker-compose/docker-compose.service.ts
@@ -117,7 +117,7 @@ export class DockerComposeService {
         mcService.expose.some((value: string | number) => String(value) === internalPort);
       const port = usesProxyCompose ? defaultPort : mcService.ports?.[0]?.split(':')[0] ?? defaultPort;
       const extraPorts = usesProxyCompose ? (mcService.ports || []) : mcService.ports?.slice(1) || [];
-      const defaultVersion = edition === 'BEDROCK' ? 'LATEST' : 'latest';
+      const defaultVersion = edition === 'BEDROCK' ? 'LATEST' : env.TYPE === 'GTNH' ? '1.7.10' : 'latest';
 
       const serverConfig: ServerConfig = {
         id: env.ID_MANAGER ?? serverId,
@@ -143,7 +143,7 @@ export class DockerComposeService {
         worldScope: this.parseWorldScope(env.WORLD),
         worldLevelName: edition === 'BEDROCK' ? env.LEVEL_NAME ?? env.LEVEL : env.LEVEL ?? 'world',
         forceWorldCopy: env.FORCE_WORLD_COPY === 'TRUE' || env.FORCE_WORLD_COPY === 'true',
-        levelType: this.parseLevelType(env.LEVEL_TYPE, edition),
+        levelType: this.parseLevelType(env.LEVEL_TYPE, edition, env.TYPE),
         hardcore: env.HARDCORE === 'true',
         spawnAnimals: env.SPAWN_ANIMALS !== 'false',
         spawnMonsters: env.SPAWN_MONSTERS !== 'false',
@@ -228,6 +228,9 @@ export class DockerComposeService {
         modrinthDownloadDependencies: 'none',
         modrinthDefaultVersionType: 'release',
         modrinthLoader: '',
+        gtnhPackVersion: env.GTNH_PACK_VERSION ?? '2.8.1',
+        gtnhDeleteBackups: env.GTNH_DELETE_BACKUPS === 'true',
+        skipGtnhUpdateCheck: env.SKIP_GTNH_UPDATE_CHECK === 'true',
 
         // Proxy config from labels or env
         proxyHostname: this.extractProxyHostname(mcService.labels),
@@ -256,10 +259,11 @@ export class DockerComposeService {
   private parseLevelType(
     levelType: string | undefined,
     edition: ServerEdition,
-  ): 'minecraft:default' | 'minecraft:flat' | 'minecraft:large_biomes' | 'minecraft:amplified' | 'minecraft:single_biome_surface' {
-    const validTypes = ['minecraft:default', 'minecraft:flat', 'minecraft:large_biomes', 'minecraft:amplified', 'minecraft:single_biome_surface'] as const;
+    serverType?: string,
+  ): 'minecraft:default' | 'minecraft:flat' | 'minecraft:large_biomes' | 'minecraft:amplified' | 'minecraft:single_biome_surface' | 'rwg' {
+    const validTypes = ['minecraft:default', 'minecraft:flat', 'minecraft:large_biomes', 'minecraft:amplified', 'minecraft:single_biome_surface', 'rwg'] as const;
 
-    if (!levelType) return 'minecraft:default';
+    if (!levelType) return serverType === 'GTNH' ? 'rwg' : 'minecraft:default';
 
     // Bedrock uses uppercase values (DEFAULT, FLAT), map them back to minecraft: format
     if (edition === 'BEDROCK') {
@@ -302,9 +306,10 @@ export class DockerComposeService {
     const knownEnvVars = new Set(['ID_MANAGER', 'EULA', 'MOTD', 'SERVER_NAME', 'DIFFICULTY', 'MAX_PLAYERS', 'OPS', 'TZ', 'ONLINE_MODE', 'PVP', 'ENABLE_COMMAND_BLOCK', 'ALLOW_FLIGHT', 'VIEW_DISTANCE', 'SIMULATION_DISTANCE', 'STOP_SERVER_ANNOUNCE_DELAY', 'ENABLE_ROLLING_LOGS', 'EXEC_DIRECTLY', 'PLAYER_IDLE_TIMEOUT', 'ENTITY_BROADCAST_RANGE_PERCENTAGE', 'LEVEL_TYPE', 'MODE', 'HARDCORE', 'SPAWN_ANIMALS', 'SPAWN_MONSTERS', 'SPAWN_NPCS', 'GENERATE_STRUCTURES', 'ALLOW_NETHER', 'UID', 'GID', 'INIT_MEMORY', 'MAX_MEMORY', 'SEED', 'VERSION', 'TYPE', 'ENABLE_AUTOSTOP', 'AUTOSTOP_TIMEOUT_EST', 'AUTOSTOP_TIMEOUT_INIT', 'ENABLE_AUTOPAUSE', 'AUTOPAUSE_TIMEOUT_EST', 'AUTOPAUSE_TIMEOUT_INIT', 'AUTOPAUSE_KNOCK_INTERFACE', 'PREVENT_PROXY_CONNECTIONS', 'OP_PERMISSION_LEVEL', 'ENABLE_RCON', 'RCON_PORT', 'RCON_PASSWORD', 'BROADCAST_RCON_TO_OPS', 'USE_AIKAR_FLAGS', 'ENABLE_JMX', 'JMX_HOST', 'JVM_OPTS', 'JVM_XX_OPTS', 'JVM_DD_OPTS', 'EXTRA_ARGS', 'LOG_TIMESTAMP', 'FORGE_VERSION', 'NEOFORGE_VERSION', 'FABRIC_LOADER_VERSION', 'FABRIC_LAUNCHER_VERSION', 'FABRIC_LAUNCHER', 'FABRIC_LAUNCHER_URL', 'FABRIC_FORCE_REINSTALL', 'MODRINTH_PROJECTS', 'MODRINTH_DOWNLOAD_DEPENDENCIES', 'MODRINTH_PROJECTS_DEFAULT_VERSION_TYPE', 'MODRINTH_LOADER', 'MODRINTH_MODPACK', 'CF_API_KEY', 'CURSEFORGE_FILES', 'CF_PAGE_URL', 'CF_SLUG', 'CF_FILE_ID', 'CF_FORCE_SYNCHRONIZE', 'CF_FORCE_INCLUDE_MODS', 'CF_EXCLUDE_MODS', 'CF_FILENAME_MATCHER', 'CF_PARALLEL_DOWNLOADS', 'CF_OVERRIDES_SKIP_EXISTING', 'CF_SET_LEVEL_FROM', 'MODPACK_PLATFORM', 'CF_SERVER_MOD', 'CF_BASE_DIR', 'USE_MODPACK_START_SCRIPT', 'FTB_LEGACYJAVAFIXER', 'SPIGET_RESOURCES', 'SKIP_DOWNLOAD_DEFAULTS', 'PAPER_BUILD', 'PAPER_CHANNEL', 'PAPER_DOWNLOAD_URL', 'BUKKIT_DOWNLOAD_URL', 'BUILD_FROM_SOURCE', 'SPIGOT_DOWNLOAD_URL', 'PUFFERFISH_BUILD', 'USE_FLARE_FLAGS', 'PURPUR_BUILD', 'PURPUR_DOWNLOAD_URL', 'LEAF_BUILD', 'FOLIA_BUILD', 'FOLIA_CHANNEL', 'FOLIA_DOWNLOAD_URL', 'GAMEMODE', 'WHITE_LIST', 'ALLOW_CHEATS', 'TICK_DISTANCE', 'MAX_THREADS', 'DEFAULT_PLAYER_PERMISSION_LEVEL', 'TEXTUREPACK_REQUIRED']);
 
     const knownWorldVars = new Set(['LEVEL', 'LEVEL_NAME', 'WORLD', 'FORCE_WORLD_COPY']);
+    const knownGtnhVars = new Set(['GTNH_PACK_VERSION', 'GTNH_DELETE_BACKUPS', 'SKIP_GTNH_UPDATE_CHECK']);
     const customVars: string[] = [];
     for (const [key, value] of Object.entries(env)) {
-      if (!knownEnvVars.has(key) && !knownWorldVars.has(key) && value !== undefined && value !== null) {
+      if (!knownEnvVars.has(key) && !knownWorldVars.has(key) && !knownGtnhVars.has(key) && value !== undefined && value !== null) {
         customVars.push(`${key}=${value}`);
       }
     }
@@ -428,6 +433,11 @@ export class DockerComposeService {
         serverConfig.cfBaseDir = env.CF_BASE_DIR ?? '/data';
         serverConfig.useModpackStartScript = env.USE_MODPACK_START_SCRIPT !== 'false';
         serverConfig.ftbLegacyJavaFixer = env.FTB_LEGACYJAVAFIXER === 'true';
+      },
+      GTNH: () => {
+        serverConfig.gtnhPackVersion = env.GTNH_PACK_VERSION ?? '2.8.1';
+        serverConfig.gtnhDeleteBackups = env.GTNH_DELETE_BACKUPS === 'true';
+        serverConfig.skipGtnhUpdateCheck = env.SKIP_GTNH_UPDATE_CHECK === 'true';
       },
     };
 
@@ -663,6 +673,9 @@ export class DockerComposeService {
       modrinthDownloadDependencies: 'none',
       modrinthDefaultVersionType: 'release',
       modrinthLoader: '',
+      gtnhPackVersion: '2.8.1',
+      gtnhDeleteBackups: false,
+      skipGtnhUpdateCheck: false,
 
       proxyHostname: undefined,
       useProxy: true,
@@ -1205,12 +1218,19 @@ export class DockerComposeService {
 
     // Only add resource limits for Java (Bedrock doesn't use JVM)
     if (edition === 'JAVA') {
-      mcService.deploy = {
-        resources: {
-          limits: { cpus: config.cpuLimit, memory: config.maxMemory },
-          reservations: { cpus: config.cpuReservation, memory: config.memoryReservation },
-        },
-      };
+      const limits = Object.fromEntries(
+        Object.entries({ cpus: config.cpuLimit, memory: config.maxMemory }).filter(([, value]) => value !== undefined && value !== ''),
+      );
+      const reservations = Object.fromEntries(
+        Object.entries({ cpus: config.cpuReservation, memory: config.memoryReservation }).filter(([, value]) => value !== undefined && value !== ''),
+      );
+      const resources = Object.fromEntries(
+        Object.entries({ limits, reservations }).filter(([, value]) => Object.keys(value).length > 0),
+      );
+
+      if (Object.keys(resources).length > 0) {
+        mcService.deploy = { resources };
+      }
     }
 
     // Si usa proxy, no exponer puerto al host; si no, exponer como siempre

--- a/backend/src/proxy/proxy.service.spec.ts
+++ b/backend/src/proxy/proxy.service.spec.ts
@@ -1,0 +1,81 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ConfigService } from '@nestjs/config';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import * as fs from 'fs-extra';
+import * as yaml from 'js-yaml';
+import { ProxyService } from './proxy.service';
+import { Settings } from 'src/users/entities/settings.entity';
+
+jest.mock('fs-extra', () => ({
+  ensureDir: jest.fn().mockResolvedValue(undefined),
+  pathExists: jest.fn().mockResolvedValue(false),
+  readJson: jest.fn(),
+  writeJson: jest.fn().mockResolvedValue(undefined),
+  readFile: jest.fn(),
+}));
+
+describe('ProxyService', () => {
+  let service: ProxyService;
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        ProxyService,
+        {
+          provide: ConfigService,
+          useValue: {
+            get: jest.fn((key: string) => {
+              if (key === 'serversDir') return '/app/servers';
+              return null;
+            }),
+          },
+        },
+        {
+          provide: getRepositoryToken(Settings),
+          useValue: {
+            find: jest.fn().mockResolvedValue([{ preferences: { proxyEnabled: true, proxyBaseDomain: 'proxy.test' } }]),
+            findOne: jest.fn().mockResolvedValue(null),
+          },
+        },
+      ],
+    }).compile();
+
+    service = module.get<ProxyService>(ProxyService);
+  });
+
+  it('returns null when server disables proxy even if proxy is globally enabled', async () => {
+    (fs.pathExists as jest.Mock).mockImplementation(async (target: string) => target === '/app/servers/survival/docker-compose.yml');
+    (fs.readFile as unknown as jest.Mock).mockResolvedValue(
+      yaml.dump({
+        services: {
+          mc: {
+            labels: ['minepanel.proxy.enabled=false'],
+          },
+        },
+      }),
+    );
+
+    const hostname = await service.getServerHostname('survival');
+
+    expect(hostname).toBeNull();
+  });
+
+  it('uses custom server hostname when no route mapping exists yet', async () => {
+    (fs.pathExists as jest.Mock).mockImplementation(async (target: string) => target === '/app/servers/survival/docker-compose.yml');
+    (fs.readFile as unknown as jest.Mock).mockResolvedValue(
+      yaml.dump({
+        services: {
+          mc: {
+            labels: ['minepanel.proxy.enabled=true', 'minepanel.proxy.hostname=lobby'],
+          },
+        },
+      }),
+    );
+
+    const hostname = await service.getServerHostname('survival');
+
+    expect(hostname).toBe('lobby.proxy.test');
+  });
+});

--- a/backend/src/proxy/proxy.service.ts
+++ b/backend/src/proxy/proxy.service.ts
@@ -4,6 +4,7 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import * as fs from 'fs-extra';
 import * as path from 'node:path';
+import * as yaml from 'js-yaml';
 import { Settings } from 'src/users/entities/settings.entity';
 
 export interface ProxyMapping {
@@ -26,6 +27,7 @@ interface ServerProxyInfo {
 @Injectable()
 export class ProxyService {
   private readonly logger = new Logger(ProxyService.name);
+  private readonly SERVERS_DIR: string;
   private readonly PROXY_DIR: string;
   private readonly ROUTES_FILE: string;
 
@@ -34,6 +36,7 @@ export class ProxyService {
     @InjectRepository(Settings)
     private readonly settingsRepo: Repository<Settings>,
   ) {
+    this.SERVERS_DIR = this.configService.get('serversDir');
     // Use /app/data for files written by backend (not BASE_DIR which is for host paths)
     this.PROXY_DIR = '/app/data/proxy';
     this.ROUTES_FILE = path.join(this.PROXY_DIR, 'routes.json');
@@ -136,10 +139,43 @@ export class ProxyService {
 
     const proxySettings = await this.getProxySettings();
     if (proxySettings.enabled && proxySettings.baseDomain) {
-      return this.generateHostname(serverId, proxySettings.baseDomain);
+      return this.getConfiguredServerHostname(serverId, proxySettings.baseDomain);
     }
 
     return null;
+  }
+
+  private async getConfiguredServerHostname(serverId: string, baseDomain: string): Promise<string | null> {
+    try {
+      const dockerComposePath = path.join(this.SERVERS_DIR, serverId, 'docker-compose.yml');
+      if (!(await fs.pathExists(dockerComposePath))) {
+        return this.generateHostname(serverId, baseDomain);
+      }
+
+      const content = await fs.readFile(dockerComposePath, 'utf8');
+      const compose = yaml.load(content) as { services?: { mc?: { labels?: string[] | Record<string, string> } } };
+      const labels = compose?.services?.mc?.labels;
+      const getLabel = (key: string): string | undefined => {
+        if (Array.isArray(labels)) {
+          return labels.find((label) => label.startsWith(`${key}=`))?.split('=').slice(1).join('=');
+        }
+
+        if (labels && typeof labels === 'object') {
+          return labels[key];
+        }
+
+        return undefined;
+      };
+
+      if (getLabel('minepanel.proxy.enabled') === 'false') {
+        return null;
+      }
+
+      return this.generateHostname(serverId, baseDomain, getLabel('minepanel.proxy.hostname'));
+    } catch (error) {
+      this.logger.warn(`Failed to load configured proxy hostname for ${serverId}`, error);
+      return this.generateHostname(serverId, baseDomain);
+    }
   }
 
   async getAllMappings(): Promise<ProxyMapping[]> {

--- a/backend/src/server-management/dto/server-config.model.ts
+++ b/backend/src/server-management/dto/server-config.model.ts
@@ -20,9 +20,9 @@ export class ServerConfigDto {
   @IsOptional()
   edition?: ServerEdition;
 
-  @IsEnum(['VANILLA', 'FORGE', 'NEOFORGE', 'AUTO_CURSEFORGE', 'CURSEFORGE', 'MODRINTH', 'SPIGOT', 'FABRIC', 'MAGMA', 'PAPER', 'QUILT', 'BUKKIT', 'PUFFERFISH', 'PURPUR', 'LEAF', 'FOLIA'])
+  @IsEnum(['VANILLA', 'FORGE', 'NEOFORGE', 'AUTO_CURSEFORGE', 'CURSEFORGE', 'MODRINTH', 'GTNH', 'SPIGOT', 'FABRIC', 'MAGMA', 'PAPER', 'QUILT', 'BUKKIT', 'PUFFERFISH', 'PURPUR', 'LEAF', 'FOLIA'])
   @IsOptional()
-  serverType?: 'VANILLA' | 'FORGE' | 'NEOFORGE' | 'AUTO_CURSEFORGE' | 'CURSEFORGE' | 'MODRINTH' | 'SPIGOT' | 'FABRIC' | 'MAGMA' | 'PAPER' | 'QUILT' | 'BUKKIT' | 'PUFFERFISH' | 'PURPUR' | 'LEAF' | 'FOLIA';
+  serverType?: 'VANILLA' | 'FORGE' | 'NEOFORGE' | 'AUTO_CURSEFORGE' | 'CURSEFORGE' | 'MODRINTH' | 'GTNH' | 'SPIGOT' | 'FABRIC' | 'MAGMA' | 'PAPER' | 'QUILT' | 'BUKKIT' | 'PUFFERFISH' | 'PURPUR' | 'LEAF' | 'FOLIA';
 
   // General configuration
   @IsString()
@@ -89,9 +89,9 @@ export class ServerConfigDto {
   @IsOptional()
   forceWorldCopy?: boolean;
 
-  @IsEnum(['minecraft:default', 'minecraft:flat', 'minecraft:large_biomes', 'minecraft:amplified', 'minecraft:single_biome_surface'])
+  @IsEnum(['minecraft:default', 'minecraft:flat', 'minecraft:large_biomes', 'minecraft:amplified', 'minecraft:single_biome_surface', 'rwg'])
   @IsOptional()
-  levelType?: 'minecraft:default' | 'minecraft:flat' | 'minecraft:large_biomes' | 'minecraft:amplified' | 'minecraft:single_biome_surface';
+  levelType?: 'minecraft:default' | 'minecraft:flat' | 'minecraft:large_biomes' | 'minecraft:amplified' | 'minecraft:single_biome_surface' | 'rwg';
 
   @IsBoolean()
   @IsOptional()
@@ -409,6 +409,19 @@ export class ServerConfigDto {
   @IsString()
   @IsOptional()
   modrinthModpack?: string;
+
+  // GTNH specific
+  @IsString()
+  @IsOptional()
+  gtnhPackVersion?: string;
+
+  @IsBoolean()
+  @IsOptional()
+  gtnhDeleteBackups?: boolean;
+
+  @IsBoolean()
+  @IsOptional()
+  skipGtnhUpdateCheck?: boolean;
 
   // Ports
   @IsString({ each: true })

--- a/backend/src/server-management/dto/server-list-item.dto.ts
+++ b/backend/src/server-management/dto/server-list-item.dto.ts
@@ -5,7 +5,7 @@ export class ServerListItemDto {
   serverName: string;
   motd: string;
   port: string;
-  serverType: 'VANILLA' | 'FORGE' | 'NEOFORGE' | 'AUTO_CURSEFORGE' | 'CURSEFORGE' | 'MODRINTH' | 'SPIGOT' | 'FABRIC' | 'MAGMA' | 'PAPER' | 'QUILT' | 'BUKKIT' | 'PUFFERFISH' | 'PURPUR' | 'LEAF' | 'FOLIA';
+  serverType: 'VANILLA' | 'FORGE' | 'NEOFORGE' | 'AUTO_CURSEFORGE' | 'CURSEFORGE' | 'MODRINTH' | 'GTNH' | 'SPIGOT' | 'FABRIC' | 'MAGMA' | 'PAPER' | 'QUILT' | 'BUKKIT' | 'PUFFERFISH' | 'PURPUR' | 'LEAF' | 'FOLIA';
   active: boolean;
 
   static fromServerConfig(config: ServerConfig): ServerListItemDto {

--- a/backend/src/server-management/server-management.controller.ts
+++ b/backend/src/server-management/server-management.controller.ts
@@ -114,7 +114,8 @@ export class ServerManagementController {
     }
 
     return Object.entries(defaults).reduce((acc, [key, value]) => {
-      if (JAVA_SERVER_DEFAULT_KEYS.has(key) && value !== undefined) {
+      const isBlankString = typeof value === 'string' && value.trim() === '';
+      if (JAVA_SERVER_DEFAULT_KEYS.has(key) && value !== undefined && !isBlankString) {
         acc[key] = value;
       }
       return acc;

--- a/backend/src/server-management/strategies/java-server.strategy.ts
+++ b/backend/src/server-management/strategies/java-server.strategy.ts
@@ -52,6 +52,7 @@ export class JavaServerStrategy implements IServerStrategy {
       'AUTO_CURSEFORGE',
       'CURSEFORGE',
       'MODRINTH',
+      'GTNH',
       'SPIGOT',
       'FABRIC',
       'MAGMA',
@@ -86,7 +87,7 @@ export class JavaServerStrategy implements IServerStrategy {
       EXEC_DIRECTLY: String(config.execDirectly),
       PLAYER_IDLE_TIMEOUT: config.playerIdleTimeout,
       ENTITY_BROADCAST_RANGE_PERCENTAGE: config.entityBroadcastRange,
-      LEVEL_TYPE: config.levelType,
+      LEVEL_TYPE: this.resolveLevelType(config),
       MODE: config.gameMode,
       HARDCORE: String(config.hardcore),
       SPAWN_ANIMALS: String(config.spawnAnimals),
@@ -110,7 +111,7 @@ export class JavaServerStrategy implements IServerStrategy {
     this.addServerTypeConfig(env, config);
     this.addCustomEnvVars(env, config);
 
-    return env;
+    return Object.fromEntries(Object.entries(env).filter(([, value]) => value !== undefined && value !== ''));
   }
 
   private addJvmOptions(env: Record<string, string>, config: ServerConfig): void {
@@ -211,6 +212,7 @@ export class JavaServerStrategy implements IServerStrategy {
       AUTO_CURSEFORGE: () => this.addAutoCurseForgeConfig(env, config),
       CURSEFORGE: () => this.addManualCurseForgeConfig(env, config),
       MODRINTH: () => this.addModrinthConfig(env, config),
+      GTNH: () => this.addGtnhConfig(env, config),
       SPIGOT: () => this.addPluginServerConfig(env, config),
       PAPER: () => this.addPluginServerConfig(env, config),
       BUKKIT: () => this.addPluginServerConfig(env, config),
@@ -242,6 +244,20 @@ export class JavaServerStrategy implements IServerStrategy {
     if (config.serverType === 'MODRINTH') {
       env['MODRINTH_MODPACK'] = config.modrinthModpack;
     }
+  }
+
+  private addGtnhConfig(env: Record<string, string>, config: ServerConfig): void {
+    if (config.gtnhPackVersion) env['GTNH_PACK_VERSION'] = config.gtnhPackVersion;
+    if (config.gtnhDeleteBackups) env['GTNH_DELETE_BACKUPS'] = 'true';
+    if (config.skipGtnhUpdateCheck) env['SKIP_GTNH_UPDATE_CHECK'] = 'true';
+  }
+
+  private resolveLevelType(config: ServerConfig): string {
+    if (config.serverType !== 'GTNH' && config.levelType === 'rwg') {
+      return 'minecraft:default';
+    }
+
+    return config.levelType;
   }
 
   private addCurseForgeFilesConfig(env: Record<string, string>, config: ServerConfig): void {

--- a/backend/src/users/services/settings.service.ts
+++ b/backend/src/users/services/settings.service.ts
@@ -106,7 +106,8 @@ export class SettingsService {
 
   private sanitizeJavaServerDefaults(defaults: Record<string, any>): Record<string, any> {
     return Object.entries(defaults).reduce((acc, [key, value]) => {
-      if (this.javaDefaultsKeys.has(key) && value !== undefined) {
+      const isBlankString = typeof value === 'string' && value.trim() === '';
+      if (this.javaDefaultsKeys.has(key) && value !== undefined && !isBlankString) {
         acc[key] = value;
       }
       return acc;

--- a/config.json
+++ b/config.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.10.4",
+  "version": "1.10.5",
   "description": "Minecraft Docker Manager - Control panel for managing Minecraft servers via Docker",
   "author": "ketbome",
   "license": "MIT"

--- a/doc/features.md
+++ b/doc/features.md
@@ -27,7 +27,7 @@ flowchart LR
 | ---------------- | -------------------------------------------------------------------- |
 | Java & Bedrock   | Both Minecraft editions supported                                    |
 | Multiple servers | Run as many as hardware allows, isolated containers                  |
-| All server types | Vanilla, Paper, Forge, Neoforge, Fabric, Purpur, CurseForge modpacks |
+| All server types | Vanilla, Paper, Forge, Neoforge, Fabric, Purpur, GTNH, CurseForge and Modrinth modpacks |
 | Any version      | 1.8 to latest, snapshots included                                    |
 | Templates        | Pre-configured: Survival, Creative, SkyBlock, PvP, etc.              |
 | Java defaults    | Global defaults for new Java servers (offline mode, resources, backup switch) |

--- a/doc/mods-plugins.md
+++ b/doc/mods-plugins.md
@@ -329,6 +329,24 @@ For `AUTO_CURSEFORGE`, `CF_SET_LEVEL_FROM` and the Java **Worlds** tab are alter
 
 Minepanel includes a **Browse** button to search CurseForge modpacks directly from the UI. Click it to find and select modpacks without leaving the panel.
 
+## GTNH {#gtnh}
+
+Minepanel also supports **GT New Horizons** through the dedicated **GTNH** server type.
+
+Use it when you want the container to handle GTNH-specific install and update behavior without manually entering env vars.
+
+Available GTNH fields in Minepanel:
+
+- `GTNH_PACK_VERSION`
+- `GTNH_DELETE_BACKUPS`
+- `SKIP_GTNH_UPDATE_CHECK`
+
+Recommended workflow:
+
+1. Keep a fixed pack version such as `2.8.1`
+2. Leave update check enabled for the first install
+3. Only enable `SKIP_GTNH_UPDATE_CHECK` after the server has been installed once
+
 ## CurseForge Files (Individual Mods) {#curseforge-files}
 
 Download specific mods/plugins from [CurseForge](https://www.curseforge.com) to add to any modded server.

--- a/doc/server-types.md
+++ b/doc/server-types.md
@@ -1,16 +1,16 @@
 ---
 title: Server Types - Minepanel | Java & Bedrock Edition Support
-description: Complete guide to Minecraft server types in Minepanel - Java Edition (Vanilla, Paper, Spigot, Forge, Neoforge, Fabric, Purpur, Folia, CurseForge modpacks) and Bedrock Edition servers with full configuration.
+description: Complete guide to Minecraft server types in Minepanel - Java Edition (Vanilla, Paper, Spigot, Forge, Neoforge, Fabric, Purpur, Folia, GTNH, CurseForge modpacks) and Bedrock Edition servers with full configuration.
 head:
   - - meta
     - name: keywords
-      content: minecraft server types, paper server, forge server, neoforge server, fabric server, purpur server, bedrock server, vanilla server, spigot server, curseforge modpacks, minecraft editions
+      content: minecraft server types, paper server, forge server, neoforge server, fabric server, purpur server, gtnh server, bedrock server, vanilla server, spigot server, curseforge modpacks, minecraft editions
   - - meta
     - property: og:title
       content: Minecraft Server Types - Minepanel
   - - meta
     - property: og:description
-      content: Configure Java Edition (Vanilla, Paper, Forge, Neoforge, Fabric, Purpur) and Bedrock Edition servers with Minepanel.
+      content: Configure Java Edition (Vanilla, Paper, Forge, Neoforge, Fabric, Purpur, GTNH) and Bedrock Edition servers with Minepanel.
 ---
 
 # Server Types
@@ -360,6 +360,36 @@ environment:
   TYPE: MODRINTH
   MODRINTH_MODPACK: https://modrinth.com/modpack/surface-living/version/1.2.1
 ```
+
+## GT New Horizons (GTNH)
+
+Install GT New Horizons using the dedicated **GTNH** server type.
+
+### Recommended defaults in Minepanel
+
+- `TYPE=GTNH`
+- `GTNH_PACK_VERSION=2.8.1`
+- `GTNH_DELETE_BACKUPS=false`
+- `SKIP_GTNH_UPDATE_CHECK=false`
+- `LEVEL_TYPE=rwg`
+- `DIFFICULTY=hard`
+- `ALLOW_FLIGHT=true`
+- `ENABLE_COMMAND_BLOCK=true`
+
+### GTNH options
+
+| Option              | Variable                  | Description                                              | Default |
+| ------------------- | ------------------------- | -------------------------------------------------------- | ------- |
+| Pack Version        | `GTNH_PACK_VERSION`       | `latest`, `latest-dev`, or a fixed version like `2.8.1` | `2.8.1` |
+| Delete Backups      | `GTNH_DELETE_BACKUPS`     | Remove config backup folders created during upgrades     | `false` |
+| Skip Update Check   | `SKIP_GTNH_UPDATE_CHECK`  | Skip the GTNH update/install check after first install   | `false` |
+
+### Notes
+
+- GTNH targets Minecraft `1.7.10`
+- Java `17+` is recommended
+- `java25` is preferred for GTNH `2.8.0+`
+- Enable `SKIP_GTNH_UPDATE_CHECK` only after the initial install if you want to freeze updates
 
 ## CurseForge Modpacks
 

--- a/frontend/src/app/dashboard/settings/network/page.tsx
+++ b/frontend/src/app/dashboard/settings/network/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useEffect, useState } from 'react';
-import { Globe, Info, Loader2, Network, Save } from 'lucide-react';
+import { AlertTriangle, Globe, Info, Loader2, Network, Save } from 'lucide-react';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
@@ -24,6 +24,7 @@ export default function NetworkSettingsPage() {
   const [publicIp, setPublicIp] = useState('');
   const [lanIp, setLanIp] = useState('');
   const [canManageSystemSettings, setCanManageSystemSettings] = useState(false);
+  const proxyToggleChanged = proxySettings.enabled !== initialProxyEnabled;
 
   useEffect(() => {
     Promise.all([getSettings(), getCurrentUser()])
@@ -115,6 +116,12 @@ export default function NetworkSettingsPage() {
             </div>
             <Switch checked={proxySettings.enabled} onCheckedChange={(checked) => setProxySettings((current) => ({ ...current, enabled: checked }))} disabled={!proxyBaseDomain} />
           </div>
+          {proxyToggleChanged ? (
+            <div className="flex items-start gap-2 rounded-lg border border-amber-600/30 bg-amber-900/20 p-3">
+              <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0 text-amber-400" />
+              <p className="text-xs text-amber-300">{t('proxyToggleWarning')}</p>
+            </div>
+          ) : null}
           {!proxyBaseDomain ? (
             <div className="flex items-start gap-2 rounded-lg border border-amber-600/30 bg-amber-900/20 p-3">
               <Info className="mt-0.5 h-4 w-4 shrink-0 text-amber-400" />

--- a/frontend/src/components/molecules/Tabs/ModsTab.tsx
+++ b/frontend/src/components/molecules/Tabs/ModsTab.tsx
@@ -41,6 +41,7 @@ export const ModsTab: FC<ModsTabProps> = ({ config, updateConfig }) => {
   const isCurseForge = config.serverType === "AUTO_CURSEFORGE";
   const isManualCurseForge = config.serverType === "CURSEFORGE";
   const isModrinth = config.serverType === "MODRINTH";
+  const isGtnh = config.serverType === "GTNH";
   const isForge = config.serverType === "FORGE";
   const isNeoforge = config.serverType === "NEOFORGE";
   const isFabric = config.serverType === "FABRIC";
@@ -149,7 +150,7 @@ export const ModsTab: FC<ModsTabProps> = ({ config, updateConfig }) => {
     return "added";
   };
 
-  if (!isCurseForge && !isForge && !isNeoforge && !isManualCurseForge && !isFabric &&!isModrinth) {
+  if (!isCurseForge && !isForge && !isNeoforge && !isManualCurseForge && !isFabric && !isModrinth && !isGtnh) {
     return (
       <Card className="bg-gray-900/60 border-gray-700/50 shadow-lg">
         <CardHeader className="pb-3">
@@ -871,6 +872,65 @@ export const ModsTab: FC<ModsTabProps> = ({ config, updateConfig }) => {
               </div>
               <Textarea id="cfFiles" value={config.cfFiles} onChange={(e) => updateConfig("cfFiles", e.target.value)} placeholder="jei, geckolib, aquaculture" className="min-h-20 bg-gray-800/70 border-gray-700/50 text-gray-200 focus:border-emerald-500/50 focus:ring-emerald-500/30" />
               <p className="text-xs text-gray-400">{t("curseforgeFilesDesc")}</p>
+            </div>
+          </>
+        )}
+
+        {isGtnh && (
+          <>
+            <div className="rounded-md border border-amber-600/30 bg-amber-900/20 p-4">
+              <div className="flex items-start gap-3">
+                <Info className="mt-0.5 h-5 w-5 shrink-0 text-amber-400" />
+                <div className="space-y-1 text-sm text-amber-100/90">
+                  <p className="font-minecraft text-amber-300">{t("gtnhRequirementsTitle")}</p>
+                  <p>{t("gtnhRequirementsBody")}</p>
+                  <p>{t("gtnhJavaNote")}</p>
+                </div>
+              </div>
+            </div>
+
+            <div className="space-y-2 rounded-md border border-amber-500/30 bg-gray-800/50 p-4">
+              <Label htmlFor="gtnhPackVersion" className="text-amber-300 font-minecraft text-sm">
+                {t("gtnhPackVersion")}
+              </Label>
+              <Input
+                id="gtnhPackVersion"
+                value={config.gtnhPackVersion || "2.8.1"}
+                onChange={(e) => updateConfig("gtnhPackVersion", e.target.value)}
+                placeholder="2.8.1"
+                className="bg-gray-800/70 border-gray-700/50 text-gray-200 focus:border-amber-500/50 focus:ring-amber-500/30"
+              />
+              <p className="text-xs text-gray-400">{t("gtnhPackVersionDesc")}</p>
+            </div>
+
+            <div className="space-y-4 rounded-md border border-gray-700/50 bg-gray-800/50 p-4">
+              <div className="flex items-center justify-between gap-4">
+                <div>
+                  <Label htmlFor="gtnhDeleteBackups" className="text-gray-200 font-minecraft text-sm">
+                    {t("gtnhDeleteBackups")}
+                  </Label>
+                  <p className="text-xs text-gray-400 mt-1">{t("gtnhDeleteBackupsDesc")}</p>
+                </div>
+                <Switch
+                  id="gtnhDeleteBackups"
+                  checked={config.gtnhDeleteBackups === true}
+                  onCheckedChange={(checked) => updateConfig("gtnhDeleteBackups", checked)}
+                />
+              </div>
+
+              <div className="flex items-center justify-between gap-4">
+                <div>
+                  <Label htmlFor="skipGtnhUpdateCheck" className="text-gray-200 font-minecraft text-sm">
+                    {t("skipGtnhUpdateCheck")}
+                  </Label>
+                  <p className="text-xs text-gray-400 mt-1">{t("skipGtnhUpdateCheckDesc")}</p>
+                </div>
+                <Switch
+                  id="skipGtnhUpdateCheck"
+                  checked={config.skipGtnhUpdateCheck === true}
+                  onCheckedChange={(checked) => updateConfig("skipGtnhUpdateCheck", checked)}
+                />
+              </div>
             </div>
           </>
         )}

--- a/frontend/src/components/molecules/Tabs/ServerTypeTab.tsx
+++ b/frontend/src/components/molecules/Tabs/ServerTypeTab.tsx
@@ -30,7 +30,7 @@ export const ServerTypeTab: FC<ServerTypeTabProps> = ({ config, updateConfig }) 
   const isJava = edition === 'JAVA';
   const isBedrock = edition === 'BEDROCK';
   const isModpack =
-    config.serverType === 'AUTO_CURSEFORGE' || config.serverType === 'CURSEFORGE' || config.serverType === 'MODRINTH';
+    config.serverType === 'AUTO_CURSEFORGE' || config.serverType === 'CURSEFORGE' || config.serverType === 'MODRINTH' || config.serverType === 'GTNH';
 
   const { versions, loading, latestRelease, refresh, getRecommended } = useMinecraftVersions({
     filterType: 'release',
@@ -44,6 +44,30 @@ export const ServerTypeTab: FC<ServerTypeTabProps> = ({ config, updateConfig }) 
 
   const recommendedIds = new Set(recommendedVersions.map((v) => v.id));
   const otherVersions = versions.filter((v) => v.id !== latestRelease && !recommendedIds.has(v.id));
+
+  const handleServerTypeChange = (newType: ServerType) => {
+    updateConfig('serverType', newType);
+
+    if (newType === 'GTNH') {
+      updateConfig('minecraftVersion', '1.7.10');
+      updateConfig('levelType', 'rwg');
+      updateConfig('difficulty', 'hard');
+      updateConfig('allowFlight', true);
+      updateConfig('commandBlock', true);
+      updateConfig('gtnhPackVersion', config.gtnhPackVersion || '2.8.1');
+      updateConfig('gtnhDeleteBackups', config.gtnhDeleteBackups ?? false);
+      updateConfig('skipGtnhUpdateCheck', config.skipGtnhUpdateCheck ?? false);
+
+      if (
+        !config.motd ||
+        config.motd === 'A Minecraft server' ||
+        config.motd === 'An incredible Minecraft server' ||
+        config.motd.startsWith('Greg Tech New Horizon')
+      ) {
+        updateConfig('motd', `Greg Tech New Horizon ${config.gtnhPackVersion || '2.8.1'}`);
+      }
+    }
+  };
 
   const handleEditionChange = (newEdition: ServerEdition) => {
     // Don't allow edition change if server already exists
@@ -396,7 +420,7 @@ export const ServerTypeTab: FC<ServerTypeTabProps> = ({ config, updateConfig }) 
             <h3 className="text-sm font-minecraft text-gray-300 mb-4">{t('selectType')}</h3>
             <RadioGroup
               value={config.serverType}
-              onValueChange={(value: ServerType) => updateConfig('serverType', value)}
+              onValueChange={(value: ServerType) => handleServerTypeChange(value)}
               className="space-y-4"
             >
               <div
@@ -565,6 +589,23 @@ export const ServerTypeTab: FC<ServerTypeTabProps> = ({ config, updateConfig }) 
                     </Label>
                   </div>
                   <p className="text-sm text-gray-300 mt-1">{t('serverModrinth')}</p>
+                </div>
+              </div>
+
+              <div
+                className={`flex items-start space-x-4 rounded-md p-4 transition-transform duration-200 hover:scale-[1.01] ${config.serverType === 'GTNH' ? 'bg-amber-600/10 border border-amber-600/30' : 'bg-gray-800/40 border border-gray-700/50 hover:bg-gray-800/60'}`}
+              >
+                <div className="relative flex items-center justify-center w-10 h-10 rounded-md bg-gray-800/70 border border-gray-700/50 shrink-0">
+                  <Image src="/images/anvil.webp" alt="GTNH" width={24} height={24} />
+                </div>
+                <div className="flex-1">
+                  <div className="flex items-center space-x-2">
+                    <RadioGroupItem value="GTNH" id="gtnh" className="border-amber-600/50" />
+                    <Label htmlFor="gtnh" className="text-base font-medium text-gray-100 font-minecraft">
+                      GT New Horizons
+                    </Label>
+                  </div>
+                  <p className="text-sm text-gray-300 mt-1">{t('serverGtnh')}</p>
                 </div>
               </div>
 

--- a/frontend/src/components/molecules/Tabs/SettingsTabs/WorldSettingsTab.tsx
+++ b/frontend/src/components/molecules/Tabs/SettingsTabs/WorldSettingsTab.tsx
@@ -21,6 +21,7 @@ interface WorldSettingsTabProps {
 export const WorldSettingsTab: FC<WorldSettingsTabProps> = ({ serverId, serverStatus, config, updateConfig }) => {
   const { t } = useLanguage();
   const isJava = config.edition !== "BEDROCK";
+  const isGtnh = config.serverType === 'GTNH';
 
   return (
     <div className="space-y-6">
@@ -46,6 +47,7 @@ export const WorldSettingsTab: FC<WorldSettingsTabProps> = ({ serverId, serverSt
             <SelectContent className="bg-gray-800 border-gray-700 text-white">
               <SelectItem value="minecraft:default">{t("normal")}</SelectItem>
               <SelectItem value="minecraft:flat">{t("flat")}</SelectItem>
+              {isGtnh && <SelectItem value="rwg">{t("gtnhWorldType")}</SelectItem>}
               {isJava && (
                 <>
                   <SelectItem value="minecraft:large_biomes">{t("largeBiomes")}</SelectItem>

--- a/frontend/src/components/organisms/ServerConfigTabs.tsx
+++ b/frontend/src/components/organisms/ServerConfigTabs.tsx
@@ -35,7 +35,7 @@ export const ServerConfigTabs: FC<ServerConfigTabsProps> = ({ serverId, config, 
   const isBedrock = config.edition === "BEDROCK";
 
   // Java-only tabs
-  const showModsTab = isJava && (config.serverType === "FORGE" || config.serverType === "NEOFORGE" || config.serverType === "FABRIC" || config.serverType === "AUTO_CURSEFORGE" || config.serverType === "CURSEFORGE" || config.serverType === 'MODRINTH');
+  const showModsTab = isJava && (config.serverType === "FORGE" || config.serverType === "NEOFORGE" || config.serverType === "FABRIC" || config.serverType === "AUTO_CURSEFORGE" || config.serverType === "CURSEFORGE" || config.serverType === 'MODRINTH' || config.serverType === 'GTNH');
   const showPluginsTab = isJava && (config.serverType === "SPIGOT" || config.serverType === "PAPER" || config.serverType === "BUKKIT" || config.serverType === "PUFFERFISH" || config.serverType === "PURPUR" || config.serverType === "LEAF" || config.serverType === "FOLIA");
   const showResourcesTab = isJava; // JVM settings only apply to Java
   const showCommandsTab = isJava; // RCON only works with Java

--- a/frontend/src/lib/hooks/useServerConfig.tsx
+++ b/frontend/src/lib/hooks/useServerConfig.tsx
@@ -94,6 +94,9 @@ const defaultConfig: ServerConfig = {
   execDirectly: true,
   envVars: '',
   extraPorts: [],
+  gtnhPackVersion: '2.8.1',
+  gtnhDeleteBackups: false,
+  skipGtnhUpdateCheck: false,
   cfMethod: 'url',
   cfUrl: '',
   cfSlug: '',
@@ -160,6 +163,8 @@ export function useServerConfig(serverId: string) {
         if (!serverConfig.minecraftVersion) {
           if (serverConfig.edition === 'BEDROCK') {
             serverConfig.minecraftVersion = 'LATEST';
+          } else if (serverConfig.serverType === 'GTNH') {
+            serverConfig.minecraftVersion = '1.7.10';
           } else {
             serverConfig.minecraftVersion = 'latest';
           }

--- a/frontend/src/lib/translations/de.ts
+++ b/frontend/src/lib/translations/de.ts
@@ -1403,6 +1403,8 @@ export const de: Record<TranslationKey, string> = {
   proxyBaseDomainDesc: 'Die Domain, die für Server-Subdomains verwendet wird (z.B. mc.example.com)',
   enableProxy: 'Proxy Aktivieren',
   enableProxyDesc: 'Leite den gesamten Minecraft-Verkehr über mc-router auf Port 25565',
+  proxyToggleWarning:
+    'Stelle vor dem Speichern sicher, dass alle Server gestoppt sind. Das Ändern des globalen Proxys während Server laufen kann Probleme verursachen.',
   proxyRequiresDomain: 'Konfiguriere eine Basis-Domain, um die Proxy-Funktion zu aktivieren',
   proxyDnsInfo: 'Konfiguriere einen Wildcard-DNS-Eintrag, der auf deinen Server zeigt:',
   proxyHostname: 'Benutzerdefinierter Hostname',

--- a/frontend/src/lib/translations/de.ts
+++ b/frontend/src/lib/translations/de.ts
@@ -149,6 +149,8 @@ export const de: Record<TranslationKey, string> = {
     'Manueller Modus für CurseForge-Modpacks. Verwendet vorgeladene ZIP-Dateien. Veraltete Funktion, wir empfehlen CurseForge Modpack.',
   serverModrinth:
     'Installiert automatisch Modpacks von Modrinth. Kann über URL oder Slug des Modpacks konfiguriert werden.',
+  serverGtnh:
+    'Deploys GT New Horizons with its dedicated container mode and recommended defaults for this modpack.',
   serverSpigot: 'Optimierter Server kompatibel mit Bukkit-Plugins',
   serverPaper: 'Hochleistungsserver basierend auf Spigot mit zusätzlichen Optimierungen',
   serverBukkit: 'Klassischer Server mit Standard-Plugin-API-Unterstützung',
@@ -501,6 +503,7 @@ export const de: Record<TranslationKey, string> = {
   largeBiomes: 'Große Biome',
   amplified: 'Verstärkt',
   singleBiomeSurface: 'Einzelnes Biom Oberfläche',
+  gtnhWorldType: 'RWG (GTNH)',
 
   // World Options
   hardcore: 'Hardcore',
@@ -1133,6 +1136,20 @@ export const de: Record<TranslationKey, string> = {
     'Gib den Slug oder die URL des Modrinth-Modpacks ein, das du verwenden möchtest.',
   modrinthModpackTooltip:
     'Gib den Modrinth-Projekt-Slug oder die URL ein. Du kannst auch eine spezifische Version angeben (z. B. https://modrinth.com/modpack/surface-living/version/1.2.1).',
+  gtnhRequirementsTitle: 'GTNH recommended resources',
+  gtnhRequirementsBody:
+    'Use 2-4 CPU cores, at least 6 GB of RAM, extra RAM per player, and 20 GB or more of storage. SSD is preferred.',
+  gtnhJavaNote:
+    'GTNH supports Java 8 and 17+. Java 17+ is recommended, and java25 is the preferred option for GTNH 2.8.0 and later.',
+  gtnhPackVersion: 'GTNH Pack Version',
+  gtnhPackVersionDesc:
+    'Use a fixed version such as 2.8.1 for controlled upgrades, or latest/latest-dev if you want automatic updates.',
+  gtnhDeleteBackups: 'Delete GTNH config backups on startup',
+  gtnhDeleteBackupsDesc:
+    'Deletes the backup folders created by GTNH when config files are replaced during upgrades.',
+  skipGtnhUpdateCheck: 'Skip GTNH update check',
+  skipGtnhUpdateCheckDesc:
+    'Disable update checks after the first installation if you want to prevent automatic GTNH updates from running.',
 
   // Manual CurseForge (Deprecated)
   deprecatedFeature: 'Veraltete Funktion',

--- a/frontend/src/lib/translations/en.ts
+++ b/frontend/src/lib/translations/en.ts
@@ -1378,6 +1378,8 @@ export const en = {
   proxyBaseDomainDesc: 'The domain that will be used for server subdomains (e.g., mc.example.com)',
   enableProxy: 'Enable Proxy',
   enableProxyDesc: 'Route all Minecraft traffic through mc-router on port 25565',
+  proxyToggleWarning:
+    'Before saving, make sure all servers are stopped. Changing the global proxy while servers are running can cause issues.',
   proxyRequiresDomain: 'Configure a base domain to enable the proxy feature',
   proxyDnsInfo: 'Configure a wildcard DNS record pointing to your server:',
   proxyHostname: 'Custom Hostname',

--- a/frontend/src/lib/translations/en.ts
+++ b/frontend/src/lib/translations/en.ts
@@ -147,6 +147,8 @@ export const en = {
     'Manual mode for CurseForge modpacks. Uses preloaded ZIP files. Obsolete feature, we recommend using CurseForge Modpack.',
   serverModrinth:
     "Automatically installs modpacks from Modrinth. Can be configured using the modpack's URL, or slug.",
+  serverGtnh:
+    'Deploys GT New Horizons with its dedicated container mode and recommended defaults for this modpack.',
   serverSpigot: 'Optimized server compatible with Bukkit plugins',
   serverPaper: 'High-performance server based on Spigot with additional optimizations',
   serverBukkit: 'Classic server with standard plugin API support',
@@ -499,6 +501,7 @@ export const en = {
   largeBiomes: 'Large Biomes',
   amplified: 'Amplified',
   singleBiomeSurface: 'Single Biome Surface',
+  gtnhWorldType: 'RWG (GTNH)',
 
   // World Options
   hardcore: 'Hardcore',
@@ -1117,6 +1120,20 @@ export const en = {
   modrinthModpackDesc: 'Enter the slug or URL of the Modrinth modpack you want to use.',
   modrinthModpackTooltip:
     'Enter the Modrinth project slug or URL. You can also include a specific version (e.g., https://modrinth.com/modpack/surface-living/version/1.2.1).',
+  gtnhRequirementsTitle: 'GTNH recommended resources',
+  gtnhRequirementsBody:
+    'Use 2-4 CPU cores, at least 6 GB of RAM, extra RAM per player, and 20 GB or more of storage. SSD is preferred.',
+  gtnhJavaNote:
+    'GTNH supports Java 8 and 17+. Java 17+ is recommended, and java25 is the preferred option for GTNH 2.8.0 and later.',
+  gtnhPackVersion: 'GTNH Pack Version',
+  gtnhPackVersionDesc:
+    'Use a fixed version such as 2.8.1 for controlled upgrades, or latest/latest-dev if you want automatic updates.',
+  gtnhDeleteBackups: 'Delete GTNH config backups on startup',
+  gtnhDeleteBackupsDesc:
+    'Deletes the backup folders created by GTNH when config files are replaced during upgrades.',
+  skipGtnhUpdateCheck: 'Skip GTNH update check',
+  skipGtnhUpdateCheckDesc:
+    'Disable update checks after the first installation if you want to prevent automatic GTNH updates from running.',
 
   // Manual CurseForge (Deprecated)
   deprecatedFeature: 'Deprecated Feature',

--- a/frontend/src/lib/translations/es.ts
+++ b/frontend/src/lib/translations/es.ts
@@ -149,6 +149,8 @@ export const es: Record<TranslationKey, string> = {
     'Modo manual para modpacks de CurseForge. Utiliza archivos ZIP precargados. Función obsoleta, recomendamos usar CurseForge Modpack.',
   serverModrinth:
     'Instala automáticamente modpacks de Modrinth. Se puede configurar mediante URL, o Slug.',
+  serverGtnh:
+    'Despliega GT New Horizons con su modo dedicado del contenedor y valores recomendados para este modpack.',
   serverSpigot: 'Servidor optimizado compatible con plugins de Bukkit',
   serverPaper: 'Servidor de alto rendimiento basado en Spigot con optimizaciones adicionales',
   serverBukkit: 'Servidor clásico con soporte de plugins API estándar',
@@ -502,6 +504,7 @@ export const es: Record<TranslationKey, string> = {
   largeBiomes: 'Biomas Amplios',
   amplified: 'Amplificado',
   singleBiomeSurface: 'Bioma Único',
+  gtnhWorldType: 'RWG (GTNH)',
 
   // Opciones del Mundo
   hardcore: 'Hardcore',
@@ -1115,6 +1118,20 @@ export const es: Record<TranslationKey, string> = {
   modrinthModpackDesc: 'Introduce el slug o la URL del modpack de Modrinth que quieres usar.',
   modrinthModpackTooltip:
     'Introduce el slug o la URL del proyecto de Modrinth. También puedes incluir una versión específica (p. ej., https://modrinth.com/modpack/surface-living/version/1.2.1).',
+  gtnhRequirementsTitle: 'Recursos recomendados para GTNH',
+  gtnhRequirementsBody:
+    'Usa 2-4 núcleos de CPU, al menos 6 GB de RAM, RAM extra por jugador y 20 GB o más de almacenamiento. Se recomienda SSD.',
+  gtnhJavaNote:
+    'GTNH soporta Java 8 y 17+. Se recomienda Java 17+, y java25 es la opción preferida para GTNH 2.8.0 en adelante.',
+  gtnhPackVersion: 'Versión del pack GTNH',
+  gtnhPackVersionDesc:
+    'Usa una versión fija como 2.8.1 para controlar upgrades, o latest/latest-dev si quieres actualizaciones automáticas.',
+  gtnhDeleteBackups: 'Eliminar backups de configuración GTNH al iniciar',
+  gtnhDeleteBackupsDesc:
+    'Elimina las carpetas de backup que GTNH crea cuando reemplaza archivos de configuración durante upgrades.',
+  skipGtnhUpdateCheck: 'Omitir verificación de actualizaciones GTNH',
+  skipGtnhUpdateCheckDesc:
+    'Desactiva la verificación de actualizaciones después de la instalación inicial si quieres evitar updates automáticos de GTNH.',
 
   // CurseForge Manual (Obsoleto)
   deprecatedFeature: 'Función obsoleta (Deprecated)',

--- a/frontend/src/lib/translations/es.ts
+++ b/frontend/src/lib/translations/es.ts
@@ -1398,6 +1398,8 @@ export const es: Record<TranslationKey, string> = {
     'El dominio que se usará para los subdominios de servidores (ej: mc.example.com)',
   enableProxy: 'Habilitar Proxy',
   enableProxyDesc: 'Enrutar todo el tráfico de Minecraft a través de mc-router en el puerto 25565',
+  proxyToggleWarning:
+    'Antes de guardar, asegúrate de que todos los servidores estén apagados. Cambiar el proxy global con servidores encendidos puede causar problemas.',
   proxyRequiresDomain: 'Configura un dominio base para habilitar la función de proxy',
   proxyDnsInfo: 'Configura un registro DNS wildcard apuntando a tu servidor:',
   proxyHostname: 'Hostname Personalizado',

--- a/frontend/src/lib/translations/fr.ts
+++ b/frontend/src/lib/translations/fr.ts
@@ -147,6 +147,8 @@ export const fr = {
     "Mode manuel pour les modpacks CurseForge. Utilise des fichiers ZIP préchargés. Fonction obsolète, il est recommandé d'utiliser CurseForge Modpack.",
   serverModrinth:
     "Installe automatiquement des modpacks depuis Modrinth. Peut être configuré via l'URL ou le slug du modpack.",
+  serverGtnh:
+    'Deploys GT New Horizons with its dedicated container mode and recommended defaults for this modpack.',
   serverSpigot: 'Serveur optimisé compatible avec les plugins Bukkit',
   serverPaper: 'Serveur haute performance basé sur Spigot avec des optimisations supplémentaires',
   serverBukkit: 'Serveur classique avec prise en charge standard de l’API des plugins',
@@ -499,6 +501,7 @@ export const fr = {
   largeBiomes: 'Grands biomes',
   amplified: 'Amplifié',
   singleBiomeSurface: 'Surface à biome unique',
+  gtnhWorldType: 'RWG (GTNH)',
 
   // World Options
   hardcore: 'Hardcore',
@@ -1117,6 +1120,20 @@ export const fr = {
   modrinthModpackDesc: 'Entrez le slug ou l’URL du modpack Modrinth que vous souhaitez utiliser.',
   modrinthModpackTooltip:
     'Entrez le slug ou l’URL du projet Modrinth. Vous pouvez aussi inclure une version spécifique (ex : https://modrinth.com/modpack/surface-living/version/1.2.1).',
+  gtnhRequirementsTitle: 'GTNH recommended resources',
+  gtnhRequirementsBody:
+    'Use 2-4 CPU cores, at least 6 GB of RAM, extra RAM per player, and 20 GB or more of storage. SSD is preferred.',
+  gtnhJavaNote:
+    'GTNH supports Java 8 and 17+. Java 17+ is recommended, and java25 is the preferred option for GTNH 2.8.0 and later.',
+  gtnhPackVersion: 'GTNH Pack Version',
+  gtnhPackVersionDesc:
+    'Use a fixed version such as 2.8.1 for controlled upgrades, or latest/latest-dev if you want automatic updates.',
+  gtnhDeleteBackups: 'Delete GTNH config backups on startup',
+  gtnhDeleteBackupsDesc:
+    'Deletes the backup folders created by GTNH when config files are replaced during upgrades.',
+  skipGtnhUpdateCheck: 'Skip GTNH update check',
+  skipGtnhUpdateCheckDesc:
+    'Disable update checks after the first installation if you want to prevent automatic GTNH updates from running.',
 
   // Manual CurseForge (Deprecated)
   deprecatedFeature: 'Fonctionnalité obsolète',

--- a/frontend/src/lib/translations/fr.ts
+++ b/frontend/src/lib/translations/fr.ts
@@ -1378,6 +1378,8 @@ export const fr = {
   proxyBaseDomainDesc: 'Le domaine qui sera utilisé pour les sous-domaines des serveurs (ex. mc.example.com)',
   enableProxy: 'Activer le proxy',
   enableProxyDesc: 'Redirige tout le trafic Minecraft via mc-router sur le port 25565',
+  proxyToggleWarning:
+    'Avant d’enregistrer, assurez-vous que tous les serveurs sont arrêtés. Modifier le proxy global pendant que des serveurs tournent peut causer des problèmes.',
   proxyRequiresDomain: 'Configurez un domaine de base pour activer la fonctionnalité de proxy',
   proxyDnsInfo: 'Configurez un enregistrement DNS wildcard pointant vers votre serveur :',
   proxyHostname: 'Nom d’hôte personnalisé',

--- a/frontend/src/lib/translations/nl.ts
+++ b/frontend/src/lib/translations/nl.ts
@@ -1410,6 +1410,8 @@ export const nl: Record<TranslationKey, string> = {
     'Het domein dat wordt gebruikt voor server subdomeinen (bijv. mc.example.com)',
   enableProxy: 'Proxy Inschakelen',
   enableProxyDesc: 'Routeer al het Minecraft verkeer via mc-router op poort 25565',
+  proxyToggleWarning:
+    'Zorg ervoor dat alle servers zijn gestopt voordat je opslaat. Het wijzigen van de globale proxy terwijl servers draaien kan problemen veroorzaken.',
   proxyRequiresDomain: 'Configureer een basisdomein om de proxyfunctie in te schakelen',
   proxyDnsInfo: 'Configureer een wildcard DNS record dat naar je server wijst:',
   proxyHostname: 'Aangepaste Hostnaam',

--- a/frontend/src/lib/translations/nl.ts
+++ b/frontend/src/lib/translations/nl.ts
@@ -149,6 +149,8 @@ export const nl: Record<TranslationKey, string> = {
     'Handmatige modus voor CurseForge modpacks. (Gebruikt vooraf geladen ZIP-bestanden) (Verouderde functie, we raden aan CurseForge Modpack te gebruiken)',
   serverModrinth:
     'Installeert automatisch modpacks van Modrinth. Kan geconfigureerd worden met de URL of slug van het modpack.',
+  serverGtnh:
+    'Deploys GT New Horizons with its dedicated container mode and recommended defaults for this modpack.',
   serverSpigot: 'Geoptimaliseerde server compatibel met Bukkit plugins',
   serverPaper: 'Geoptimaliseerde server gebaseerd op Spigot met extra optimalisaties',
   serverBukkit: 'Klassieke server met plugin API ondersteuning',
@@ -512,6 +514,7 @@ export const nl: Record<TranslationKey, string> = {
   largeBiomes: 'Grote biomen',
   amplified: 'Versterkt',
   singleBiomeSurface: 'Enkel bioom oppervlak',
+  gtnhWorldType: 'RWG (GTNH)',
 
   // ===========================
   // WERELD OPTIES
@@ -1132,6 +1135,20 @@ export const nl: Record<TranslationKey, string> = {
   modrinthModpackDesc: 'Voer de slug of URL in van het Modrinth-modpack dat je wilt gebruiken.',
   modrinthModpackTooltip:
     'Voer de Modrinth-projectslug of URL in. Je kunt ook een specifieke versie opgeven (bijv. https://modrinth.com/modpack/surface-living/version/1.2.1).',
+  gtnhRequirementsTitle: 'GTNH recommended resources',
+  gtnhRequirementsBody:
+    'Use 2-4 CPU cores, at least 6 GB of RAM, extra RAM per player, and 20 GB or more of storage. SSD is preferred.',
+  gtnhJavaNote:
+    'GTNH supports Java 8 and 17+. Java 17+ is recommended, and java25 is the preferred option for GTNH 2.8.0 and later.',
+  gtnhPackVersion: 'GTNH Pack Version',
+  gtnhPackVersionDesc:
+    'Use a fixed version such as 2.8.1 for controlled upgrades, or latest/latest-dev if you want automatic updates.',
+  gtnhDeleteBackups: 'Delete GTNH config backups on startup',
+  gtnhDeleteBackupsDesc:
+    'Deletes the backup folders created by GTNH when config files are replaced during upgrades.',
+  skipGtnhUpdateCheck: 'Skip GTNH update check',
+  skipGtnhUpdateCheckDesc:
+    'Disable update checks after the first installation if you want to prevent automatic GTNH updates from running.',
 
   // Manual CurseForge (Deprecated)
   deprecatedFeature: 'Verouderde functie',

--- a/frontend/src/lib/translations/pl.ts
+++ b/frontend/src/lib/translations/pl.ts
@@ -1382,6 +1382,8 @@ export const pl: Record<TranslationKey, string> = {
   proxyBaseDomainDesc: 'Domena, która będzie używana dla subdomen serwerów (np. mc.example.com)',
   enableProxy: 'Włącz proxy',
   enableProxyDesc: 'Kieruj cały ruch Minecraft przez mc-router na porcie 25565',
+  proxyToggleWarning:
+    'Przed zapisaniem upewnij się, że wszystkie serwery są wyłączone. Zmiana globalnego proxy, gdy serwery działają, może powodować problemy.',
   proxyRequiresDomain: 'Skonfiguruj domenę bazową, aby włączyć funkcję proxy',
   proxyDnsInfo: 'Skonfiguruj rekord DNS z symbolem wieloznacznym wskazujący na Twój serwer:',
   proxyHostname: 'Niestandardowa nazwa hosta',

--- a/frontend/src/lib/translations/pl.ts
+++ b/frontend/src/lib/translations/pl.ts
@@ -149,6 +149,8 @@ export const pl: Record<TranslationKey, string> = {
     'Tryb ręczny dla paczek modów CurseForge. Używa wcześniej wgranych plików ZIP. Funkcja przestarzała — zalecamy użycie CurseForge Modpack.',
   serverModrinth:
     'Automatycznie instaluje paczki modów z Modrinth. Może być skonfigurowany przy użyciu adresu URL paczki lub jej slugu.',
+  serverGtnh:
+    'Deploys GT New Horizons with its dedicated container mode and recommended defaults for this modpack.',
   serverSpigot: 'Zoptymalizowany serwer kompatybilny z pluginami Bukkit',
   serverPaper: 'Wysokowydajny serwer oparty na Spigot z dodatkowymi optymalizacjami',
   serverBukkit: 'Klasyczny serwer ze standardowym wsparciem dla API pluginów',
@@ -495,6 +497,7 @@ export const pl: Record<TranslationKey, string> = {
   largeBiomes: 'Duże biomy',
   amplified: 'Wzmocniony',
   singleBiomeSurface: 'Powierzchnia pojedynczego biomu',
+  gtnhWorldType: 'RWG (GTNH)',
 
   // Ustawienia świata
   hardcore: 'Hardcore',
@@ -1118,6 +1121,20 @@ export const pl: Record<TranslationKey, string> = {
   modrinthModpackDesc: 'Wprowadź slug lub adres URL pakietu Modrinth, którego chcesz użyć',
   modrinthModpackTooltip:
     'Wprowadź slug lub adres URL projektu Modrinth. Możesz również podać konkretną wersję (np. https://modrinth.com/modpack/surface-living/version/1.2.1).',
+  gtnhRequirementsTitle: 'GTNH recommended resources',
+  gtnhRequirementsBody:
+    'Use 2-4 CPU cores, at least 6 GB of RAM, extra RAM per player, and 20 GB or more of storage. SSD is preferred.',
+  gtnhJavaNote:
+    'GTNH supports Java 8 and 17+. Java 17+ is recommended, and java25 is the preferred option for GTNH 2.8.0 and later.',
+  gtnhPackVersion: 'GTNH Pack Version',
+  gtnhPackVersionDesc:
+    'Use a fixed version such as 2.8.1 for controlled upgrades, or latest/latest-dev if you want automatic updates.',
+  gtnhDeleteBackups: 'Delete GTNH config backups on startup',
+  gtnhDeleteBackupsDesc:
+    'Deletes the backup folders created by GTNH when config files are replaced during upgrades.',
+  skipGtnhUpdateCheck: 'Skip GTNH update check',
+  skipGtnhUpdateCheckDesc:
+    'Disable update checks after the first installation if you want to prevent automatic GTNH updates from running.',
 
   // Manual CurseForge (Deprecated)
   deprecatedFeature: 'Przestarzała funkcja',

--- a/frontend/src/lib/types/types.d.ts
+++ b/frontend/src/lib/types/types.d.ts
@@ -13,6 +13,7 @@ export type ServerType =
   | 'AUTO_CURSEFORGE'
   | 'MODRINTH'
   | 'CURSEFORGE'
+  | 'GTNH'
   | 'SPIGOT'
   | 'FABRIC'
   | 'MAGMA'
@@ -71,7 +72,8 @@ export interface ServerConfig {
     | 'minecraft:flat'
     | 'minecraft:large_biomes'
     | 'minecraft:amplified'
-    | 'minecraft:single_biome_surface';
+    | 'minecraft:single_biome_surface'
+    | 'rwg';
   hardcore: boolean;
   spawnAnimals: boolean;
   spawnMonsters: boolean;
@@ -171,6 +173,11 @@ export interface ServerConfig {
   modrinthLoader?: string;
 
   modrinthModpack?: string;
+
+  // GTNH specific
+  gtnhPackVersion?: string;
+  gtnhDeleteBackups?: boolean;
+  skipGtnhUpdateCheck?: boolean;
 
   // CurseForge specific
   cfMethod?: 'url' | 'slug' | 'file';


### PR DESCRIPTION
## Summary
- add GT New Horizons as a supported Java server type across backend, frontend, types, defaults, and docs, including GTNH-specific options and recommended presets
- fix proxy-related runtime issues by making backup containers join the proxy network and by resolving server hostnames from each server's actual proxy configuration
- add a warning in global network settings when toggling the global proxy so admins stop servers before saving to avoid runtime issues

## Testing
- `npm test -- --runTestsByPath src/docker-compose/docker-compose.service.spec.ts src/proxy/proxy.service.spec.ts`
- `npm run lint -- --file src/app/dashboard/settings/network/page.tsx`

## Notes
- includes the version bump to `1.10.5`
- updates docs for GTNH support and available server types