### PR TITLE
fix: sync proxy behavior and simplify server type selection

### DIFF
--- a/backend/src/docker-compose/docker-compose.service.spec.ts
+++ b/backend/src/docker-compose/docker-compose.service.spec.ts
@@ -4,6 +4,12 @@ import { DockerComposeService } from './docker-compose.service';
 import * as fs from 'fs-extra';
 import * as yaml from 'js-yaml';
 
+jest.mock('node:child_process', () => ({
+  exec: jest.fn((_: string, callback: (error: Error | null, result: { stdout: string; stderr: string }) => void) => {
+    callback(null, { stdout: '', stderr: '' });
+  }),
+}));
+
 jest.mock('fs-extra', () => ({
   ensureDirSync: jest.fn(),
   ensureDir: jest.fn().mockResolvedValue(undefined),
@@ -119,6 +125,36 @@ describe('DockerComposeService', () => {
       const parsed = yaml.load(yamlContent as string) as any;
 
       expect(parsed.services.mc.networks['minepanel-network'].aliases).toEqual(['proxyserver']);
+    });
+
+    it('should reserve port 25565 for direct java servers when global proxy is enabled', async () => {
+      const config = (service as any).createDefaultConfig('direct-server');
+      config.useProxy = false;
+
+      await service.generateDockerComposeFile(config, true);
+
+      const writeFileMock = fs.writeFile as unknown as jest.Mock;
+      const [, yamlContent] = writeFileMock.mock.calls[0];
+      const parsed = yaml.load(yamlContent as string) as any;
+
+      expect(parsed.services.mc.ports).toContain('25566:25565');
+    });
+
+    it('should reserve port 25565 when mc-router is running even if global proxy is disabled', async () => {
+      const childProcess = jest.requireMock('node:child_process') as { exec: jest.Mock };
+      childProcess.exec.mockImplementation((_: string, callback: (error: Error | null, result: { stdout: string; stderr: string }) => void) => {
+        callback(null, { stdout: 'router-id\n', stderr: '' });
+      });
+
+      const config = (service as any).createDefaultConfig('router-running-server');
+
+      await service.generateDockerComposeFile(config, false);
+
+      const writeFileMock = fs.writeFile as unknown as jest.Mock;
+      const [, yamlContent] = writeFileMock.mock.calls[0];
+      const parsed = yaml.load(yamlContent as string) as any;
+
+      expect(parsed.services.mc.ports).toContain('25566:25565');
     });
 
     it('should attach backup service to proxy network when proxy is enabled', async () => {

--- a/backend/src/docker-compose/docker-compose.service.ts
+++ b/backend/src/docker-compose/docker-compose.service.ts
@@ -1,10 +1,14 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
+import { exec } from 'node:child_process';
+import { promisify } from 'node:util';
 import * as fs from 'fs-extra';
 import * as yaml from 'js-yaml';
 import * as path from 'node:path';
 import { ServerConfig, ServerEdition, UpdateServerConfig } from 'src/server-management/dto/server-config.model';
 import { ServerStrategyFactory } from 'src/server-management/strategies';
+
+const execAsync = promisify(exec);
 
 interface DockerComposeConfig {
   services?: {
@@ -52,10 +56,10 @@ export class DockerComposeService {
     };
   }
 
-  private async findAvailablePort(startPort: number, serverId: string): Promise<number> {
+  private async findAvailablePort(startPort: number, serverId: string, reservedPorts: number[] = []): Promise<number> {
     try {
       const serverIds = await this.getAllServerIds();
-      const usedPorts = new Set<number>();
+      const usedPorts = new Set<number>(reservedPorts);
 
       for (const id of serverIds) {
         if (id === serverId) continue;
@@ -73,6 +77,16 @@ export class DockerComposeService {
     } catch (error) {
       this.logger.error('Error finding available port', error);
       return startPort;
+    }
+  }
+
+  private async isMcRouterRunning(): Promise<boolean> {
+    try {
+      const { stdout } = await execAsync('docker ps --filter "name=^/mc-router$" --format "{{.ID}}"');
+      return stdout.trim().length > 0;
+    } catch (error) {
+      this.logger.warn('Failed to detect mc-router status', error);
+      return false;
     }
   }
 
@@ -1180,11 +1194,14 @@ export class DockerComposeService {
     return mountTarget === target;
   }
 
-  private async ensurePortAvailable(config: ServerConfig): Promise<string> {
+  private async ensurePortAvailable(config: ServerConfig, proxyEnabled = false): Promise<string> {
     const strategy = ServerStrategyFactory.create(config.edition ?? 'JAVA');
     const defaultPort = strategy.getDefaultPort();
     const requestedPort = Number.parseInt(config.port || defaultPort);
-    const availablePort = await this.findAvailablePort(requestedPort, config.id);
+    const usesProxy = proxyEnabled && (config.edition ?? 'JAVA') === 'JAVA' && config.useProxy !== false;
+    const reserveProxyPort = (config.edition ?? 'JAVA') === 'JAVA' && !usesProxy && (proxyEnabled || await this.isMcRouterRunning());
+    const reservedPorts = reserveProxyPort ? [Number.parseInt(defaultPort)] : [];
+    const availablePort = await this.findAvailablePort(requestedPort, config.id, reservedPorts);
     if (availablePort !== requestedPort) {
       config.port = availablePort.toString();
     }
@@ -1366,7 +1383,7 @@ export class DockerComposeService {
     // When proxy is enabled, servers don't expose ports to host, so no need to find available port
     // Note: Proxy only works with Java edition (mc-router doesn't support Bedrock)
     const useProxy = proxyEnabled && normalizedConfig.useProxy !== false && edition === 'JAVA';
-    const availablePort = useProxy ? strategy.getInternalPort() : await this.ensurePortAvailable(normalizedConfig);
+    const availablePort = useProxy ? strategy.getInternalPort() : await this.ensurePortAvailable(normalizedConfig, proxyEnabled);
     const volumes = this.parseVolumes(normalizedConfig);
     const dockerComposeConfig = this.buildDockerComposeConfig(normalizedConfig, environment, volumes, availablePort, proxyEnabled, strategy);
 

--- a/backend/src/proxy/proxy.controller.ts
+++ b/backend/src/proxy/proxy.controller.ts
@@ -1,13 +1,18 @@
-import { Controller, Get, Post, Delete, Param, Body } from '@nestjs/common';
+import { Controller, Get, Post, Delete, Param, Body, Request } from '@nestjs/common';
 import { ProxyService } from './proxy.service';
+import { PayloadToken } from 'src/auth/models/token.model';
 
 @Controller('proxy')
 export class ProxyController {
   constructor(private readonly proxyService: ProxyService) {}
 
   @Get('status')
-  async getStatus() {
-    const [proxyStatus, settings] = await Promise.all([this.proxyService.getProxyStatus(), this.proxyService.getProxySettings()]);
+  async getStatus(@Request() req) {
+    const user = req.user as PayloadToken;
+    const [proxyStatus, settings] = await Promise.all([
+      this.proxyService.getProxyStatus(),
+      this.proxyService.getProxySettings(user.userId),
+    ]);
 
     return {
       available: !!settings.baseDomain,
@@ -23,8 +28,9 @@ export class ProxyController {
   }
 
   @Get('server/:id/hostname')
-  async getServerHostname(@Param('id') serverId: string) {
-    const hostname = await this.proxyService.getServerHostname(serverId);
+  async getServerHostname(@Request() req, @Param('id') serverId: string) {
+    const user = req.user as PayloadToken;
+    const hostname = await this.proxyService.getServerHostname(serverId, user.userId);
     return { hostname };
   }
 

--- a/backend/src/proxy/proxy.service.spec.ts
+++ b/backend/src/proxy/proxy.service.spec.ts
@@ -78,4 +78,24 @@ describe('ProxyService', () => {
 
     expect(hostname).toBe('lobby.proxy.test');
   });
+
+  it('uses current user proxy settings for hostname fallback', async () => {
+    const settingsRepo = (service as any).settingsRepo;
+    settingsRepo.findOne.mockResolvedValue({ preferences: { proxyEnabled: true, proxyBaseDomain: 'user.test' } });
+
+    (fs.pathExists as jest.Mock).mockImplementation(async (target: string) => target === '/app/servers/survival/docker-compose.yml');
+    (fs.readFile as unknown as jest.Mock).mockResolvedValue(
+      yaml.dump({
+        services: {
+          mc: {
+            labels: ['minepanel.proxy.enabled=true'],
+          },
+        },
+      }),
+    );
+
+    const hostname = await service.getServerHostname('survival', 42);
+
+    expect(hostname).toBe('survival.user.test');
+  });
 });

--- a/backend/src/proxy/proxy.service.ts
+++ b/backend/src/proxy/proxy.service.ts
@@ -126,7 +126,12 @@ export class ProxyService {
     this.logger.log(`Removed server ${serverId} from proxy`);
   }
 
-  async getServerHostname(serverId: string): Promise<string | null> {
+  async clearRoutesFile(): Promise<void> {
+    await this.saveRoutesConfig({ mappings: {} });
+    this.logger.log('Cleared proxy routes.json');
+  }
+
+  async getServerHostname(serverId: string, userId?: number): Promise<string | null> {
     const config = await this.loadRoutesConfig();
     const backend = `${serverId}:25565`;
 
@@ -137,7 +142,7 @@ export class ProxyService {
       }
     }
 
-    const proxySettings = await this.getProxySettings();
+    const proxySettings = await this.getProxySettings(userId);
     if (proxySettings.enabled && proxySettings.baseDomain) {
       return this.getConfiguredServerHostname(serverId, proxySettings.baseDomain);
     }

--- a/backend/src/server-management/server-management.controller.spec.ts
+++ b/backend/src/server-management/server-management.controller.spec.ts
@@ -52,6 +52,7 @@ describe('ServerManagementController', () => {
 
     const mockProxyService = {
       generateRoutesFile: jest.fn(),
+      clearRoutesFile: jest.fn(),
       getProxySettings: jest.fn(),
       getServerHostname: jest.fn(),
     };
@@ -296,6 +297,21 @@ describe('ServerManagementController', () => {
       expect(accessControlService.assertCreateServers).toHaveBeenCalledWith(
         expect.objectContaining({ id: 1 }),
       );
+    });
+  });
+
+  describe('regenerateAllDockerCompose', () => {
+    it('should clear proxy routes when global proxy is disabled', async () => {
+      (controller as any).getCurrentUser = jest.fn().mockResolvedValue({ role: 'ADMIN' });
+      accessControlService.isAdmin.mockReturnValue(true);
+      settingsService.getSettings.mockResolvedValue({ preferences: { proxyEnabled: false, proxyBaseDomain: null } } as any);
+      dockerComposeService.regenerateAllDockerCompose.mockResolvedValue({ updated: [], errors: [] });
+
+      await controller.regenerateAllDockerCompose({ user: { userId: 1 } });
+
+      const proxyService = (controller as any).proxyService;
+      expect(proxyService.clearRoutesFile).toHaveBeenCalled();
+      expect(proxyService.generateRoutesFile).not.toHaveBeenCalled();
     });
   });
 });

--- a/backend/src/server-management/server-management.controller.ts
+++ b/backend/src/server-management/server-management.controller.ts
@@ -248,6 +248,8 @@ export class ServerManagementController {
           useProxy: true,
         }));
       await this.proxyService.generateRoutesFile(proxyServers, baseDomain);
+    } else {
+      await this.proxyService.clearRoutesFile();
     }
 
     return {

--- a/backend/src/users/services/settings.service.spec.ts
+++ b/backend/src/users/services/settings.service.spec.ts
@@ -1,0 +1,65 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { SettingsService } from './settings.service';
+import { Settings } from '../entities/settings.entity';
+import { UsersService } from './users.service';
+
+describe('SettingsService', () => {
+  let service: SettingsService;
+  let settingsRepo: { findOne: jest.Mock; save: jest.Mock };
+
+  beforeEach(async () => {
+    settingsRepo = {
+      findOne: jest.fn(),
+      save: jest.fn(async (value) => value),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        SettingsService,
+        {
+          provide: getRepositoryToken(Settings),
+          useValue: settingsRepo,
+        },
+        {
+          provide: UsersService,
+          useValue: {
+            getUserById: jest.fn().mockResolvedValue({ id: 1 }),
+          },
+        },
+      ],
+    }).compile();
+
+    service = module.get(SettingsService);
+  });
+
+  it('clears proxy domain and disables proxy when domain is blank', async () => {
+    settingsRepo.findOne.mockResolvedValue({
+      userId: 1,
+      preferences: {
+        proxyEnabled: true,
+        proxyBaseDomain: 'mc.example.com',
+      },
+    });
+
+    const result = await service.updateSettings({ proxy: { proxyEnabled: true, proxyBaseDomain: '   ' } }, 1);
+
+    expect(result.preferences.proxyBaseDomain).toBeNull();
+    expect(result.preferences.proxyEnabled).toBe(false);
+  });
+
+  it('clears network values when inputs are blank', async () => {
+    settingsRepo.findOne.mockResolvedValue({
+      userId: 1,
+      preferences: {
+        publicIp: '1.1.1.1',
+        lanIp: '192.168.1.2',
+      },
+    });
+
+    const result = await service.updateSettings({ network: { publicIp: ' ', lanIp: '' } }, 1);
+
+    expect(result.preferences.publicIp).toBeNull();
+    expect(result.preferences.lanIp).toBeNull();
+  });
+});

--- a/backend/src/users/services/settings.service.ts
+++ b/backend/src/users/services/settings.service.ts
@@ -37,6 +37,13 @@ export class SettingsService {
     private readonly usersService: UsersService,
   ) {}
 
+  private normalizeOptionalText(value: string | undefined | null): string | null | undefined {
+    if (value === undefined) return undefined;
+    if (value === null) return null;
+    const trimmed = value.trim();
+    return trimmed ? trimmed : null;
+  }
+
   async getSettings(userId: number): Promise<Settings> {
     const user = await this.usersService.getUserById(userId);
     if (!user) {
@@ -69,20 +76,29 @@ export class SettingsService {
 
     // Handle proxy settings
     if (dto.proxy) {
+      const hasProxyBaseDomain = dto.proxy.proxyBaseDomain !== undefined;
+      const proxyBaseDomain = this.normalizeOptionalText(dto.proxy.proxyBaseDomain);
+      const nextProxyBaseDomain = hasProxyBaseDomain ? (proxyBaseDomain ?? null) : (settings.preferences?.proxyBaseDomain ?? null);
+
       settings.preferences = {
         ...settings.preferences,
-        proxyEnabled: dto.proxy.proxyEnabled ?? settings.preferences?.proxyEnabled ?? false,
-        proxyBaseDomain: dto.proxy.proxyBaseDomain ?? settings.preferences?.proxyBaseDomain ?? null,
+        proxyEnabled: nextProxyBaseDomain ? (dto.proxy.proxyEnabled ?? settings.preferences?.proxyEnabled ?? false) : false,
+        proxyBaseDomain: nextProxyBaseDomain,
       };
       delete (dto as any).proxy;
     }
 
     // Handle network settings
     if (dto.network) {
+      const hasPublicIp = dto.network.publicIp !== undefined;
+      const hasLanIp = dto.network.lanIp !== undefined;
+      const publicIp = this.normalizeOptionalText(dto.network.publicIp);
+      const lanIp = this.normalizeOptionalText(dto.network.lanIp);
+
       settings.preferences = {
         ...settings.preferences,
-        publicIp: dto.network.publicIp ?? settings.preferences?.publicIp ?? null,
-        lanIp: dto.network.lanIp ?? settings.preferences?.lanIp ?? null,
+        publicIp: hasPublicIp ? (publicIp ?? null) : (settings.preferences?.publicIp ?? null),
+        lanIp: hasLanIp ? (lanIp ?? null) : (settings.preferences?.lanIp ?? null),
       };
       delete (dto as any).network;
     }

--- a/frontend/src/app/dashboard/settings/network/page.tsx
+++ b/frontend/src/app/dashboard/settings/network/page.tsx
@@ -49,8 +49,8 @@ export default function NetworkSettingsPage() {
     setIsSaving(true);
     try {
       await updateSettings({
-        proxy: { proxyEnabled: proxySettings.enabled, proxyBaseDomain: proxyBaseDomain || undefined },
-        network: { publicIp: publicIp || undefined, lanIp: lanIp || undefined },
+        proxy: { proxyEnabled: proxySettings.enabled, proxyBaseDomain },
+        network: { publicIp, lanIp },
       });
 
       const proxyChanged = proxySettings.enabled !== initialProxyEnabled || proxyBaseDomain !== initialProxyDomain;

--- a/frontend/src/components/molecules/Tabs/ServerTypeTab.tsx
+++ b/frontend/src/components/molecules/Tabs/ServerTypeTab.tsx
@@ -1,4 +1,4 @@
-import { FC, useState } from 'react';
+import { FC, useEffect, useState } from 'react';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Label } from '@/components/ui/label';
 import { Input } from '@/components/ui/input';
@@ -18,11 +18,14 @@ import {
   SelectValue,
 } from '@/components/ui/select';
 import { Badge } from '@/components/ui/badge';
+import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from '@/components/ui/accordion';
 
 interface ServerTypeTabProps {
   config: ServerConfig;
   updateConfig: <K extends keyof ServerConfig>(field: K, value: ServerConfig[K]) => void;
 }
+
+const OTHER_SERVER_TYPES: ServerType[] = ['NEOFORGE', 'CURSEFORGE', 'MODRINTH', 'GTNH', 'SPIGOT', 'PAPER', 'BUKKIT'];
 
 export const ServerTypeTab: FC<ServerTypeTabProps> = ({ config, updateConfig }) => {
   const { t } = useLanguage();
@@ -38,12 +41,21 @@ export const ServerTypeTab: FC<ServerTypeTabProps> = ({ config, updateConfig }) 
   });
 
   const [showManualInput, setShowManualInput] = useState(false);
+  const [serverTypeAccordion, setServerTypeAccordion] = useState<string | undefined>(
+    OTHER_SERVER_TYPES.includes(config.serverType) ? 'others' : undefined,
+  );
   const recommendedVersions = getRecommended();
 
   const filteredRecommendedVersions = recommendedVersions.filter((v) => v.id !== latestRelease);
 
   const recommendedIds = new Set(recommendedVersions.map((v) => v.id));
   const otherVersions = versions.filter((v) => v.id !== latestRelease && !recommendedIds.has(v.id));
+
+  useEffect(() => {
+    if (OTHER_SERVER_TYPES.includes(config.serverType)) {
+      setServerTypeAccordion('others');
+    }
+  }, [config.serverType]);
 
   const handleServerTypeChange = (newType: ServerType) => {
     updateConfig('serverType', newType);
@@ -468,26 +480,6 @@ export const ServerTypeTab: FC<ServerTypeTabProps> = ({ config, updateConfig }) 
               </div>
 
               <div
-                className={`flex items-start space-x-4 rounded-md p-4 transition-transform duration-200 hover:scale-[1.01] ${config.serverType === 'NEOFORGE' ? 'bg-emerald-600/10 border border-emerald-600/30' : 'bg-gray-800/40 border border-gray-700/50 hover:bg-gray-800/60'}`}
-              >
-                <div className="relative flex items-center justify-center w-10 h-10 rounded-md bg-gray-800/70 border border-gray-700/50 shrink-0">
-                  <Image src="/images/neoforged.png" alt="Neoforge" width={24} height={24} />
-                </div>
-                <div className="flex-1">
-                  <div className="flex items-center space-x-2">
-                    <RadioGroupItem value="NEOFORGE" id="neoforge" className="border-emerald-600/50" />
-                    <Label
-                      htmlFor="neoforge"
-                      className="text-base font-medium text-gray-100 font-minecraft"
-                    >
-                      Neoforge
-                    </Label>
-                  </div>
-                  <p className="text-sm text-gray-300 mt-1">{t('serverNeoforge')}</p>
-                </div>
-              </div>
-
-              <div
                 className={`flex items-start space-x-4 rounded-md p-4 transition-transform duration-200 hover:scale-[1.01] ${config.serverType === 'FABRIC' ? 'bg-emerald-600/10 border border-emerald-600/30' : 'bg-gray-800/40 border border-gray-700/50 hover:bg-gray-800/60'}`}
               >
                 <div className="relative flex items-center justify-center w-10 h-10 rounded-md bg-gray-800/70 border border-gray-700/50 shrink-0">
@@ -536,138 +528,142 @@ export const ServerTypeTab: FC<ServerTypeTabProps> = ({ config, updateConfig }) 
                 </div>
               </div>
 
-              <div
-                className={`flex items-start space-x-4 rounded-md p-4 transition-transform duration-200 hover:scale-[1.01] ${config.serverType === 'CURSEFORGE' ? 'bg-amber-600/10 border border-amber-600/30' : 'bg-gray-800/40 border border-gray-700/50 hover:bg-gray-800/60'}`}
+              <Accordion
+                type="single"
+                collapsible
+                value={serverTypeAccordion}
+                onValueChange={setServerTypeAccordion}
+                className="w-full rounded-md border border-gray-700/50 bg-gray-800/30"
               >
-                <div className="relative flex items-center justify-center w-10 h-10 rounded-md bg-gray-800/70 border border-gray-700/50 shrink-0">
-                  <Image src="/images/book.webp" alt="CurseForge Manual" width={24} height={24} />
-                  <div className="absolute -top-1 -right-1 bg-amber-500 text-black text-xs px-1 rounded text-[8px] font-bold">
-                    LEGACY
-                  </div>
-                </div>
-                <div className="flex-1">
-                  <div className="flex items-center space-x-2">
-                    <RadioGroupItem
-                      value="CURSEFORGE"
-                      id="curseforge-manual"
-                      className="border-amber-600/50"
-                    />
-                    <Label
-                      htmlFor="curseforge-manual"
-                      className="text-base font-medium text-gray-100 font-minecraft"
+                <AccordionItem value="others" className="border-b-0">
+                  <AccordionTrigger className="px-4 py-3 text-sm font-minecraft text-gray-200 hover:bg-gray-700/30">
+                    {t('serverTypeOthers')}
+                  </AccordionTrigger>
+                  <AccordionContent className="space-y-4 px-4 pb-4 pt-1">
+                    <div
+                      className={`flex items-start space-x-4 rounded-md p-4 transition-transform duration-200 hover:scale-[1.01] ${config.serverType === 'NEOFORGE' ? 'bg-emerald-600/10 border border-emerald-600/30' : 'bg-gray-800/40 border border-gray-700/50 hover:bg-gray-800/60'}`}
                     >
-                      CurseForge Manual (Deprecated)
-                    </Label>
-                  </div>
-                  <p className="text-sm text-gray-300 mt-1">{t('serverCurseForgeManual')}</p>
-                </div>
-              </div>
+                      <div className="relative flex items-center justify-center w-10 h-10 rounded-md bg-gray-800/70 border border-gray-700/50 shrink-0">
+                        <Image src="/images/neoforged.png" alt="Neoforge" width={24} height={24} />
+                      </div>
+                      <div className="flex-1">
+                        <div className="flex items-center space-x-2">
+                          <RadioGroupItem value="NEOFORGE" id="neoforge" className="border-emerald-600/50" />
+                          <Label htmlFor="neoforge" className="text-base font-medium text-gray-100 font-minecraft">
+                            Neoforge
+                          </Label>
+                        </div>
+                        <p className="text-sm text-gray-300 mt-1">{t('serverNeoforge')}</p>
+                      </div>
+                    </div>
 
-              <div
-                className={`flex items-start space-x-4 rounded-md p-4 transition-transform duration-200 hover:scale-[1.01] ${config.serverType === 'MODRINTH' ? 'bg-emerald-600/10 border border-emerald-600/30' : 'bg-gray-800/40 border border-gray-700/50 hover:bg-gray-800/60'}`}
-              >
-                <div className="relative flex items-center justify-center w-10 h-10 rounded-md bg-gray-800/70 border border-gray-700/50 shrink-0">
-                  <Image
-                    src="/images/modrinth.svg"
-                    alt="CurseForge"
-                    width={24}
-                    height={24}
-                  />
-                </div>
-                <div className="flex-1">
-                  <div className="flex items-center space-x-2">
-                    <RadioGroupItem
-                      value="MODRINTH"
-                      id="modrinth"
-                      className="border-emerald-600/50"
-                    />
-                    <Label
-                      htmlFor="modrinth"
-                      className="text-base font-medium text-gray-100 font-minecraft"
+                    <div
+                      className={`flex items-start space-x-4 rounded-md p-4 transition-transform duration-200 hover:scale-[1.01] ${config.serverType === 'CURSEFORGE' ? 'bg-amber-600/10 border border-amber-600/30' : 'bg-gray-800/40 border border-gray-700/50 hover:bg-gray-800/60'}`}
                     >
-                      Modrinth Modpack
-                    </Label>
-                  </div>
-                  <p className="text-sm text-gray-300 mt-1">{t('serverModrinth')}</p>
-                </div>
-              </div>
+                      <div className="relative flex items-center justify-center w-10 h-10 rounded-md bg-gray-800/70 border border-gray-700/50 shrink-0">
+                        <Image src="/images/book.webp" alt="CurseForge Manual" width={24} height={24} />
+                        <div className="absolute -top-1 -right-1 bg-amber-500 text-black text-xs px-1 rounded text-[8px] font-bold">
+                          LEGACY
+                        </div>
+                      </div>
+                      <div className="flex-1">
+                        <div className="flex items-center space-x-2">
+                          <RadioGroupItem value="CURSEFORGE" id="curseforge-manual" className="border-amber-600/50" />
+                          <Label htmlFor="curseforge-manual" className="text-base font-medium text-gray-100 font-minecraft">
+                            CurseForge Manual (Deprecated)
+                          </Label>
+                        </div>
+                        <p className="text-sm text-gray-300 mt-1">{t('serverCurseForgeManual')}</p>
+                      </div>
+                    </div>
 
-              <div
-                className={`flex items-start space-x-4 rounded-md p-4 transition-transform duration-200 hover:scale-[1.01] ${config.serverType === 'GTNH' ? 'bg-amber-600/10 border border-amber-600/30' : 'bg-gray-800/40 border border-gray-700/50 hover:bg-gray-800/60'}`}
-              >
-                <div className="relative flex items-center justify-center w-10 h-10 rounded-md bg-gray-800/70 border border-gray-700/50 shrink-0">
-                  <Image src="/images/anvil.webp" alt="GTNH" width={24} height={24} />
-                </div>
-                <div className="flex-1">
-                  <div className="flex items-center space-x-2">
-                    <RadioGroupItem value="GTNH" id="gtnh" className="border-amber-600/50" />
-                    <Label htmlFor="gtnh" className="text-base font-medium text-gray-100 font-minecraft">
-                      GT New Horizons
-                    </Label>
-                  </div>
-                  <p className="text-sm text-gray-300 mt-1">{t('serverGtnh')}</p>
-                </div>
-              </div>
-
-              <div
-                className={`flex items-start space-x-4 rounded-md p-4 transition-transform duration-200 hover:scale-[1.01] ${config.serverType === 'SPIGOT' ? 'bg-emerald-600/10 border border-emerald-600/30' : 'bg-gray-800/40 border border-gray-700/50 hover:bg-gray-800/60'}`}
-              >
-                <div className="relative flex items-center justify-center w-10 h-10 rounded-md bg-gray-800/70 border border-gray-700/50 shrink-0">
-                  <Image src="/images/redstone.webp" alt="Spigot" width={24} height={24} />
-                </div>
-                <div className="flex-1">
-                  <div className="flex items-center space-x-2">
-                    <RadioGroupItem value="SPIGOT" id="spigot" className="border-emerald-600/50" />
-                    <Label
-                      htmlFor="spigot"
-                      className="text-base font-medium text-gray-100 font-minecraft"
+                    <div
+                      className={`flex items-start space-x-4 rounded-md p-4 transition-transform duration-200 hover:scale-[1.01] ${config.serverType === 'MODRINTH' ? 'bg-emerald-600/10 border border-emerald-600/30' : 'bg-gray-800/40 border border-gray-700/50 hover:bg-gray-800/60'}`}
                     >
-                      Spigot
-                    </Label>
-                  </div>
-                  <p className="text-sm text-gray-300 mt-1">{t('serverSpigot')}</p>
-                </div>
-              </div>
+                      <div className="relative flex items-center justify-center w-10 h-10 rounded-md bg-gray-800/70 border border-gray-700/50 shrink-0">
+                        <Image src="/images/modrinth.svg" alt="Modrinth" width={24} height={24} />
+                      </div>
+                      <div className="flex-1">
+                        <div className="flex items-center space-x-2">
+                          <RadioGroupItem value="MODRINTH" id="modrinth" className="border-emerald-600/50" />
+                          <Label htmlFor="modrinth" className="text-base font-medium text-gray-100 font-minecraft">
+                            Modrinth Modpack
+                          </Label>
+                        </div>
+                        <p className="text-sm text-gray-300 mt-1">{t('serverModrinth')}</p>
+                      </div>
+                    </div>
 
-              <div
-                className={`flex items-start space-x-4 rounded-md p-4 transition-transform duration-200 hover:scale-[1.01] ${config.serverType === 'PAPER' ? 'bg-emerald-600/10 border border-emerald-600/30' : 'bg-gray-800/40 border border-gray-700/50 hover:bg-gray-800/60'}`}
-              >
-                <div className="relative flex items-center justify-center w-10 h-10 rounded-md bg-gray-800/70 border border-gray-700/50 shrink-0">
-                  <Image src="/images/paper.webp" alt="Paper" width={24} height={24} />
-                </div>
-                <div className="flex-1">
-                  <div className="flex items-center space-x-2">
-                    <RadioGroupItem value="PAPER" id="paper" className="border-emerald-600/50" />
-                    <Label
-                      htmlFor="paper"
-                      className="text-base font-medium text-gray-100 font-minecraft"
+                    <div
+                      className={`flex items-start space-x-4 rounded-md p-4 transition-transform duration-200 hover:scale-[1.01] ${config.serverType === 'GTNH' ? 'bg-amber-600/10 border border-amber-600/30' : 'bg-gray-800/40 border border-gray-700/50 hover:bg-gray-800/60'}`}
                     >
-                      Paper
-                    </Label>
-                  </div>
-                  <p className="text-sm text-gray-300 mt-1">{t('serverPaper')}</p>
-                </div>
-              </div>
+                      <div className="relative flex items-center justify-center w-10 h-10 rounded-md bg-gray-800/70 border border-gray-700/50 shrink-0">
+                        <Image src="/images/anvil.webp" alt="GTNH" width={24} height={24} />
+                      </div>
+                      <div className="flex-1">
+                        <div className="flex items-center space-x-2">
+                          <RadioGroupItem value="GTNH" id="gtnh" className="border-amber-600/50" />
+                          <Label htmlFor="gtnh" className="text-base font-medium text-gray-100 font-minecraft">
+                            GT New Horizons
+                          </Label>
+                        </div>
+                        <p className="text-sm text-gray-300 mt-1">{t('serverGtnh')}</p>
+                      </div>
+                    </div>
 
-              <div
-                className={`flex items-start space-x-4 rounded-md p-4 transition-transform duration-200 hover:scale-[1.01] ${config.serverType === 'BUKKIT' ? 'bg-emerald-600/10 border border-emerald-600/30' : 'bg-gray-800/40 border border-gray-700/50 hover:bg-gray-800/60'}`}
-              >
-                <div className="relative flex items-center justify-center w-10 h-10 rounded-md bg-gray-800/70 border border-gray-700/50 shrink-0">
-                  <Image src="/images/emerald.webp" alt="Bukkit" width={24} height={24} />
-                </div>
-                <div className="flex-1">
-                  <div className="flex items-center space-x-2">
-                    <RadioGroupItem value="BUKKIT" id="bukkit" className="border-emerald-600/50" />
-                    <Label
-                      htmlFor="bukkit"
-                      className="text-base font-medium text-gray-100 font-minecraft"
+                    <div
+                      className={`flex items-start space-x-4 rounded-md p-4 transition-transform duration-200 hover:scale-[1.01] ${config.serverType === 'SPIGOT' ? 'bg-emerald-600/10 border border-emerald-600/30' : 'bg-gray-800/40 border border-gray-700/50 hover:bg-gray-800/60'}`}
                     >
-                      Bukkit
-                    </Label>
-                  </div>
-                  <p className="text-sm text-gray-300 mt-1">{t('serverBukkit')}</p>
-                </div>
-              </div>
+                      <div className="relative flex items-center justify-center w-10 h-10 rounded-md bg-gray-800/70 border border-gray-700/50 shrink-0">
+                        <Image src="/images/redstone.webp" alt="Spigot" width={24} height={24} />
+                      </div>
+                      <div className="flex-1">
+                        <div className="flex items-center space-x-2">
+                          <RadioGroupItem value="SPIGOT" id="spigot" className="border-emerald-600/50" />
+                          <Label htmlFor="spigot" className="text-base font-medium text-gray-100 font-minecraft">
+                            Spigot
+                          </Label>
+                        </div>
+                        <p className="text-sm text-gray-300 mt-1">{t('serverSpigot')}</p>
+                      </div>
+                    </div>
+
+                    <div
+                      className={`flex items-start space-x-4 rounded-md p-4 transition-transform duration-200 hover:scale-[1.01] ${config.serverType === 'PAPER' ? 'bg-emerald-600/10 border border-emerald-600/30' : 'bg-gray-800/40 border border-gray-700/50 hover:bg-gray-800/60'}`}
+                    >
+                      <div className="relative flex items-center justify-center w-10 h-10 rounded-md bg-gray-800/70 border border-gray-700/50 shrink-0">
+                        <Image src="/images/paper.webp" alt="Paper" width={24} height={24} />
+                      </div>
+                      <div className="flex-1">
+                        <div className="flex items-center space-x-2">
+                          <RadioGroupItem value="PAPER" id="paper" className="border-emerald-600/50" />
+                          <Label htmlFor="paper" className="text-base font-medium text-gray-100 font-minecraft">
+                            Paper
+                          </Label>
+                        </div>
+                        <p className="text-sm text-gray-300 mt-1">{t('serverPaper')}</p>
+                      </div>
+                    </div>
+
+                    <div
+                      className={`flex items-start space-x-4 rounded-md p-4 transition-transform duration-200 hover:scale-[1.01] ${config.serverType === 'BUKKIT' ? 'bg-emerald-600/10 border border-emerald-600/30' : 'bg-gray-800/40 border border-gray-700/50 hover:bg-gray-800/60'}`}
+                    >
+                      <div className="relative flex items-center justify-center w-10 h-10 rounded-md bg-gray-800/70 border border-gray-700/50 shrink-0">
+                        <Image src="/images/emerald.webp" alt="Bukkit" width={24} height={24} />
+                      </div>
+                      <div className="flex-1">
+                        <div className="flex items-center space-x-2">
+                          <RadioGroupItem value="BUKKIT" id="bukkit" className="border-emerald-600/50" />
+                          <Label htmlFor="bukkit" className="text-base font-medium text-gray-100 font-minecraft">
+                            Bukkit
+                          </Label>
+                        </div>
+                        <p className="text-sm text-gray-300 mt-1">{t('serverBukkit')}</p>
+                      </div>
+                    </div>
+                  </AccordionContent>
+                </AccordionItem>
+              </Accordion>
             </RadioGroup>
           </div>
         )}

--- a/frontend/src/lib/translations/de.ts
+++ b/frontend/src/lib/translations/de.ts
@@ -159,6 +159,7 @@ export const de: Record<TranslationKey, string> = {
   serverLeaf: 'Paper-Fork mit Fokus auf Leistung und Low-Level-Optimierungen',
   serverFolia: 'Experimenteller Paper-Server mit Multi-Threading-Unterstützung (Regionen)',
   selectType: 'Servertyp auswählen',
+  serverTypeOthers: 'Andere',
 
   // Server Actions
   startServer: 'Server starten',

--- a/frontend/src/lib/translations/en.ts
+++ b/frontend/src/lib/translations/en.ts
@@ -157,6 +157,7 @@ export const en = {
   serverLeaf: 'Paper fork focused on performance and low-level optimizations',
   serverFolia: 'Experimental Paper server with multi-threading support (regions)',
   selectType: 'Select server type',
+  serverTypeOthers: 'Others',
 
   // Server Actions
   startServer: 'Start Server',

--- a/frontend/src/lib/translations/es.ts
+++ b/frontend/src/lib/translations/es.ts
@@ -160,6 +160,7 @@ export const es: Record<TranslationKey, string> = {
   serverLeaf: 'Fork de Paper enfocado en rendimiento y optimizaciones de bajo nivel',
   serverFolia: 'Servidor experimental de Paper con soporte para multi-threading (regiones)',
   selectType: 'Seleccionar tipo de servidor',
+  serverTypeOthers: 'Otros',
 
   // Acciones de Servidor
   startServer: 'Iniciar Servidor',

--- a/frontend/src/lib/translations/fr.ts
+++ b/frontend/src/lib/translations/fr.ts
@@ -157,6 +157,7 @@ export const fr = {
   serverLeaf: 'Fork de Paper axé sur la performance et les optimisations bas niveau',
   serverFolia: 'Serveur Paper expérimental avec prise en charge du multi-threading (régions)',
   selectType: 'Sélectionnez le type de serveur',
+  serverTypeOthers: 'Autres',
 
   // Server Actions
   startServer: 'Démarrer le serveur',

--- a/frontend/src/lib/translations/nl.ts
+++ b/frontend/src/lib/translations/nl.ts
@@ -160,6 +160,7 @@ export const nl: Record<TranslationKey, string> = {
   serverLeaf: 'Paper fork gericht op prestaties en low-level optimalisaties',
   serverFolia: "Experimentele Paper server met multi-threading ondersteuning (voor regio's)",
   selectType: 'Selecteer een servertype',
+  serverTypeOthers: 'Overige',
 
   // Server Actions
   startServer: 'Server starten',

--- a/frontend/src/lib/translations/pl.ts
+++ b/frontend/src/lib/translations/pl.ts
@@ -160,6 +160,7 @@ export const pl: Record<TranslationKey, string> = {
   serverLeaf: 'Fork serwera Paper skoncentrowany na wydajności i niskopoziomowych optymalizacjach',
   serverFolia: 'Eksperymentalny serwer Paper z obsługą wielowątkowości (regiony)',
   selectType: 'Wybierz typ serwera',
+  serverTypeOthers: 'Inne',
 
   // Akcje server
   startServer: 'Uruchom',


### PR DESCRIPTION
## Summary
- keep proxy and network settings in sync when fields are cleared, and clear proxy routes when the global proxy is disabled
- reserve the default Java port when mc-router is active so direct servers avoid conflicts
- prioritize core server types in the UI and move the remaining options into an expandable `Others` section

## Testing
- npm run lint --prefix frontend
- npm test --prefix backend -- --runInBand src/docker-compose/docker-compose.service.spec.ts src/proxy/proxy.service.spec.ts src/server-management/server-management.controller.spec.ts src/users/services/settings.service.spec.ts