### PR TITLE
fix: generate valid yaml for docker labels with urls

### DIFF
--- a/backend/src/docker-compose/docker-compose.service.spec.ts
+++ b/backend/src/docker-compose/docker-compose.service.spec.ts
@@ -219,7 +219,7 @@ describe('DockerComposeService', () => {
 
     it('should generate valid yaml for docker labels with urls when proxy labels are also present', async () => {
       const config = (service as any).createDefaultConfig('label-server');
-      config.dockerLabels = 'net.unraid.docker.icon=https://cdn.jsdelivr.net/gh/selfhst/icons/png/minecraft.png';
+      config.dockerLabels = 'example.label=https://example.com/icon.png';
 
       await service.generateDockerComposeFile(config, true);
 
@@ -227,9 +227,7 @@ describe('DockerComposeService', () => {
       const [, yamlContent] = writeFileMock.mock.calls[0];
       const parsed = yaml.load(yamlContent as string) as any;
 
-      expect(parsed.services.mc.labels['net.unraid.docker.icon']).toBe(
-        'https://cdn.jsdelivr.net/gh/selfhst/icons/png/minecraft.png',
-      );
+      expect(parsed.services.mc.labels['example.label']).toBe('https://example.com/icon.png');
       expect(parsed.services.mc.labels['minepanel.proxy.enabled']).toBe('true');
     });
   });

--- a/backend/src/docker-compose/docker-compose.service.spec.ts
+++ b/backend/src/docker-compose/docker-compose.service.spec.ts
@@ -216,5 +216,21 @@ describe('DockerComposeService', () => {
 
       expect(parsed.services.mc.restart).toBe('no');
     });
+
+    it('should generate valid yaml for docker labels with urls when proxy labels are also present', async () => {
+      const config = (service as any).createDefaultConfig('label-server');
+      config.dockerLabels = 'net.unraid.docker.icon=https://cdn.jsdelivr.net/gh/selfhst/icons/png/minecraft.png';
+
+      await service.generateDockerComposeFile(config, true);
+
+      const writeFileMock = fs.writeFile as unknown as jest.Mock;
+      const [, yamlContent] = writeFileMock.mock.calls[0];
+      const parsed = yaml.load(yamlContent as string) as any;
+
+      expect(parsed.services.mc.labels['net.unraid.docker.icon']).toBe(
+        'https://cdn.jsdelivr.net/gh/selfhst/icons/png/minecraft.png',
+      );
+      expect(parsed.services.mc.labels['minepanel.proxy.enabled']).toBe('true');
+    });
   });
 });

--- a/backend/src/docker-compose/docker-compose.service.ts
+++ b/backend/src/docker-compose/docker-compose.service.ts
@@ -405,6 +405,19 @@ export class DockerComposeService {
     return labels.length > 0 ? labels : undefined;
   }
 
+  private buildDockerLabels(labels: string[]): Record<string, string> {
+    return Object.fromEntries(
+      labels.map((label) => {
+        const separatorIndex = label.indexOf('=');
+        if (separatorIndex === -1) {
+          return [label, ''];
+        }
+
+        return [label.slice(0, separatorIndex), label.slice(separatorIndex + 1)];
+      }),
+    );
+  }
+
   private parseServerTypeSpecificConfig(serverConfig: ServerConfig, env: any): void {
     const typeHandlers = {
       FORGE: () => {
@@ -1282,7 +1295,7 @@ export class DockerComposeService {
 
     const allLabels = [...userLabels, ...proxyLabels];
     if (allLabels.length > 0) {
-      mcService.labels = allLabels;
+      mcService.labels = this.buildDockerLabels(allLabels);
     }
 
     const result: any = {
@@ -1392,21 +1405,7 @@ export class DockerComposeService {
       await this.addBackupService(dockerComposeConfig, normalizedConfig, serverDir, useProxy);
     }
 
-    let yamlContent = yaml.dump(dockerComposeConfig);
-
-    // Wrap label values in single quotes to handle special characters (backticks, etc.)
-    yamlContent = yamlContent.replaceAll(/^(\s+labels:\n)((?:\s+-\s+.+\n)+)/gm, (match, labelsHeader, labelsBlock) => {
-      const quotedLabels = labelsBlock.replaceAll(/^(\s+-\s+)(.+)$/gm, (_, prefix, value) => {
-        // Skip if already quoted
-        if ((value.startsWith("'") && value.endsWith("'")) || (value.startsWith('"') && value.endsWith('"'))) {
-          return `${prefix}${value}`;
-        }
-        // Escape single quotes in value and wrap
-        const escaped = value.replaceAll('\'', "''");
-        return `${prefix}'${escaped}'`;
-      });
-      return labelsHeader + quotedLabels;
-    });
+    const yamlContent = yaml.dump(dockerComposeConfig, { lineWidth: -1 });
 
     await fs.writeFile(this.getDockerComposePath(normalizedConfig.id), yamlContent);
   }


### PR DESCRIPTION
## Summary
- stop patching the generated YAML `labels` block with regex after dump
- serialize docker labels as a proper YAML map so URL values do not break compose output
- keep the regression test but replace the reported external URL with a neutral `example.com` URL

## Context
This fixes the follow-up docker label issue shown in #128 screenshots, where a long URL label combined with `minepanel.proxy.enabled=true` produced invalid YAML.

## Issues
- fixes #128

## Testing
- `npm run test --prefix backend -- --runInBand docker-compose.service.spec.ts`