### PR TITLE
feat: spawn protection + auto-detect host base dir (#142, #143, #138)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -51,7 +51,7 @@ OIDC_DISABLE_PASSWORD_LOGIN=false              # true hides and blocks username/
 # -----------------------------------------------------------------------------
 # Directories
 # -----------------------------------------------------------------------------
-BASE_DIR=$PWD                                  # Base directory on host (required for Docker socket)
+BASE_DIR=$PWD                                  # Host path that maps to /app. Auto-detected from the /app/servers mount; this is only a fallback for local/non-Docker runs
 BACKUP_BASE_DIR=                               # Optional host path for backups (e.g. /network-disk/minepanel). Empty = ${BASE_DIR}/servers/<id>/backups. Per-server override available in the UI.
 COMPOSE_PROJECT=                        # Optional prefix for server compose project names (final name: <prefix>_<serverId>)
 

--- a/backend/AGENTS.md
+++ b/backend/AGENTS.md
@@ -65,7 +65,10 @@ npm run test --prefix backend
 Path and filesystem patterns (critical):
 
 - `serversDir` is container-side path (`/app/servers`) from `backend/src/config.ts`.
-- `baseDir` is host-side path (`BASE_DIR`) used in generated compose mounts.
+- `baseDir` is host-side path used in generated compose mounts. It is auto-detected at startup
+  from the host `Source` of the `/app/servers` bind (via `docker inspect` on the own container,
+  see `detectHostBaseDir` in `config.ts`); `BASE_DIR` env is only a fallback (local dev / no
+  Docker). A mismatch between env and detected path is logged.
 - Never mix `serversDir` and `baseDir`; they are not interchangeable.
 - Per-server canonical layout is:
   - `/app/servers/<serverId>/docker-compose.yml`

--- a/backend/src/config.ts
+++ b/backend/src/config.ts
@@ -1,3 +1,33 @@
+import { execSync } from 'node:child_process';
+import { dirname } from 'node:path';
+import * as os from 'node:os';
+
+// The generated server compose files and the chown helper run against the host Docker
+// daemon, so their volume paths must be host paths. BASE_DIR is the host path that maps to
+// /app. Instead of trusting the env var, ask Docker for the real source of the /app/servers
+// bind and derive BASE_DIR from it, so a misconfigured BASE_DIR can't send servers to the
+// wrong host folder. Falls back to the env var (e.g. local dev outside Docker).
+function detectHostBaseDir(): string | undefined {
+  try {
+    const containerId = process.env.HOSTNAME || os.hostname();
+    const source = execSync(`docker inspect ${containerId} --format '{{range .Mounts}}{{if eq .Destination "/app/servers"}}{{.Source}}{{end}}{{end}}'`, {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+      timeout: 5000,
+    }).trim();
+    if (source) {
+      const detected = dirname(source);
+      if (process.env.BASE_DIR && process.env.BASE_DIR !== detected) {
+        console.warn(`[config] BASE_DIR is "${process.env.BASE_DIR}" but the /app/servers mount resolves to host "${detected}". Using the detected path.`);
+      }
+      return detected;
+    }
+  } catch {
+    // Docker unavailable (e.g. local dev) -> fall back to BASE_DIR env.
+  }
+  return undefined;
+}
+
 export default () => ({
   jwtSecret: process.env.JWT_SECRET,
   jwtExpiresIn: process.env.JWT_EXPIRES_IN || '2d',
@@ -31,7 +61,7 @@ export default () => ({
     from: process.env.SMTP_FROM,
   },
   serversDir: '/app/servers',
-  baseDir: process.env.BASE_DIR || '/app',
+  baseDir: detectHostBaseDir() || process.env.BASE_DIR || '/app',
   backupBaseDir: process.env.BACKUP_BASE_DIR || undefined,
   database: {
     path: '/app/data/minepanel.db',

--- a/backend/src/server-management/dto/server-config.model.ts
+++ b/backend/src/server-management/dto/server-config.model.ts
@@ -161,6 +161,10 @@ export class ServerConfigDto {
   @IsOptional()
   opPermissionLevel?: string;
 
+  @IsString()
+  @IsOptional()
+  spawnProtection?: string;
+
   // RCON
   @IsBoolean()
   @IsOptional()

--- a/backend/src/server-management/strategies/java-server.strategy.ts
+++ b/backend/src/server-management/strategies/java-server.strategy.ts
@@ -152,6 +152,7 @@ export class JavaServerStrategy implements IServerStrategy {
   private addConnectivityOptions(env: Record<string, string>, config: ServerConfig): void {
     if (config.preventProxyConnections) env['PREVENT_PROXY_CONNECTIONS'] = 'true';
     if (config.opPermissionLevel) env['OP_PERMISSION_LEVEL'] = config.opPermissionLevel;
+    if (config.spawnProtection !== undefined && config.spawnProtection !== '') env['SPAWN_PROTECTION'] = config.spawnProtection;
   }
 
   private addWorldConfig(env: Record<string, string>, config: ServerConfig): void {

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -30,7 +30,7 @@ to edit `docker-compose.yml` to enable them — just add the variables to `.env`
 | --------------- | ------- | ------------------------- |
 | `FRONTEND_PORT` | `3000`  | Web UI port               |
 | `BACKEND_PORT`  | `8091`  | API port                  |
-| `BASE_DIR`      | `$PWD`  | Base path for server data |
+| `BASE_DIR`      | auto-detected | Host path that maps to `/app`. Auto-detected from the `/app/servers` mount; the env var is only a fallback for local dev / non-Docker runs |
 | `BACKUP_BASE_DIR` | _(empty)_ | Optional host path for backups (e.g. `/network-disk/minepanel`). Empty keeps the default `${BASE_DIR}/servers/<id>/backups`. Can be overridden per server in the UI |
 | `COMPOSE_PROJECT` | _(empty)_ | Optional prefix for per-server Docker Compose project names (`<prefix>_<serverId>`) |
 
@@ -122,11 +122,24 @@ Public IP, LAN IP, and Proxy settings are configured through the web UI:
 
 ## Advanced
 
-### Custom Base Directory
+### Base Directory (host path)
+
+`BASE_DIR` is the **absolute host path** that maps to `/app` inside the container — the directory
+that holds `servers/` and `data/`. Because each Minecraft server runs through the host Docker
+daemon (via the mounted socket), the generated compose files use host paths built from this
+value, not container paths.
+
+You normally **don't need to set it**: at startup Minepanel asks Docker for the real host source
+of the `/app/servers` mount and uses it, so the path always matches wherever you mounted the
+data. The `BASE_DIR` env var is only a fallback for local dev or non-Docker runs:
 
 ```bash
 BASE_DIR=/mnt/external/minepanel
 ```
+
+If you set `BASE_DIR` and it doesn't match the detected mount, Minepanel logs a warning and uses
+the detected path. This is why custom composes that mounted data into a subdirectory (e.g.
+`./minepanel/servers:/app/servers`) no longer end up writing servers to the wrong host folder.
 
 ### Multiple Instances
 

--- a/doc/features.md
+++ b/doc/features.md
@@ -165,6 +165,7 @@ Edit from UI:
 - Server name, MOTD
 - Max players, difficulty, game mode
 - View distance, PVP, command blocks
+- Spawn protection radius (Java, `SPAWN_PROTECTION`; `0` disables it)
 - JVM arguments, extra flags
 
 ## Server Resources (Java)

--- a/doc/mods-plugins.md
+++ b/doc/mods-plugins.md
@@ -331,6 +331,24 @@ With Slug method, the version **never updates automatically**. You must manually
 
 Useful for modpacks downloaded manually or custom modpacks.
 
+### Use the modpack URL, not the server-file URL
+
+`AUTO_CURSEFORGE` always expects the **modpack (client) page or file** — it reads the manifest
+and builds the server side from it. Pointing it at a dedicated "server files" download breaks
+with:
+
+```
+Invalid parameter provided for "install-curseforge" command:
+The modpack's manifest file was not valid - did you make sure to reference a client, not server file?
+```
+
+So use the modpack page URL (e.g. `https://www.curseforge.com/minecraft/modpacks/<pack>`) or a
+specific modpack file (`.../files/<id>`), never the server-files variant.
+
+If the install then loops or crashes on start because of a client-only mod, exclude it with the
+**Exclude mods** field (`CF_EXCLUDE_MODS`), which accepts a comma-separated list of mod slugs or
+filenames, e.g. `optifine,client-only-mod`.
+
 ### World source conflict with Worlds tab
 
 For `AUTO_CURSEFORGE`, `CF_SET_LEVEL_FROM` and the Java **Worlds** tab are alternative world-source mechanisms.

--- a/doc/troubleshooting.md
+++ b/doc/troubleshooting.md
@@ -339,6 +339,20 @@ df -h
 docker compose logs minepanel | grep -i error
 ```
 
+### Server Data Goes to the Wrong Host Folder
+
+**Symptoms:** A created server runs, but its files land somewhere other than where you mounted
+the data, or the generated `docker-compose.yml` points at a path that doesn't exist on the host.
+
+**Cause:** `BASE_DIR` (the host path that maps to `/app`) didn't match where you actually
+mounted the data. Generated server compose files use host paths derived from it.
+
+**Solution:** This is now auto-detected — Minepanel reads the real host source of the
+`/app/servers` mount at startup, so you can leave `BASE_DIR` unset and it will match your mount.
+If you previously hardcoded it to a wrong value, remove it (or fix it) and recreate the affected
+servers. If you set `BASE_DIR` and it differs from the detected path, the startup logs will warn
+you and the detected path wins. See [Configuration → Base Directory](/configuration#base-directory-host-path).
+
 ### Server Won't Start
 
 **Symptoms:** Server status shows "error" or "exited"

--- a/frontend/src/components/molecules/Tabs/SettingsTabs/WorldSettingsTab.tsx
+++ b/frontend/src/components/molecules/Tabs/SettingsTabs/WorldSettingsTab.tsx
@@ -232,6 +232,21 @@ export const WorldSettingsTab: FC<WorldSettingsTabProps> = ({ serverId, serverSt
               </div>
               <p className="text-xs text-gray-400">{t("allowNetherDescription")}</p>
             </div>
+
+            <div className="space-y-3">
+              <Label htmlFor="spawnProtection" className="text-gray-200 flex items-center gap-2">
+                <Image src="/images/structure.webp" alt={t("spawnProtection")} width={16} height={16} />
+                {t("spawnProtection")}
+              </Label>
+              <Input
+                id="spawnProtection"
+                type="number"
+                min={0}
+                value={config.spawnProtection ?? "16"}
+                onChange={(e) => updateConfig("spawnProtection", e.target.value)}
+              />
+              <p className="text-xs text-gray-400">{t("spawnProtectionDescription")}</p>
+            </div>
           </AccordionContent>
         </AccordionItem>
       </Accordion>

--- a/frontend/src/lib/hooks/useServerConfig.tsx
+++ b/frontend/src/lib/hooks/useServerConfig.tsx
@@ -47,6 +47,7 @@ const defaultConfig: ServerConfig = {
   playerIdleTimeout: '0',
   preventProxyConnections: false,
   opPermissionLevel: '4',
+  spawnProtection: '16',
   enableRcon: true,
   rconPort: '25575',
   rconPassword: '',

--- a/frontend/src/lib/translations/de.ts
+++ b/frontend/src/lib/translations/de.ts
@@ -529,6 +529,8 @@ export const de: Record<TranslationKey, string> = {
     'Definiert, ob Strukturen wie Dörfer, Tempel usw. generiert werden',
   allowNether: 'Nether erlauben',
   allowNetherDescription: 'Zugang zur Nether-Dimension aktivieren oder deaktivieren',
+  spawnProtection: 'Spawn-Schutz',
+  spawnProtectionDescription: 'Radius (in Blöcken) um den Spawn, den Nicht-Ops nicht bearbeiten können. 0 zum Deaktivieren',
 
   // ===========================
   // PERFORMANCE SETTINGS TAB

--- a/frontend/src/lib/translations/en.ts
+++ b/frontend/src/lib/translations/en.ts
@@ -527,6 +527,8 @@ export const en = {
     'Define if structures like villages, temples, etc. will be generated',
   allowNether: 'Allow Nether',
   allowNetherDescription: 'Enable or disable access to the Nether dimension',
+  spawnProtection: 'Spawn Protection',
+  spawnProtectionDescription: 'Radius (in blocks) around spawn that non-ops cannot edit. Set to 0 to disable',
 
   // ===========================
   // PERFORMANCE SETTINGS TAB

--- a/frontend/src/lib/translations/es.ts
+++ b/frontend/src/lib/translations/es.ts
@@ -529,6 +529,8 @@ export const es: Record<TranslationKey, string> = {
   generateStructuresDescription: 'Define si se generarán estructuras como aldeas, templos, etc.',
   allowNether: 'Permitir Nether',
   allowNetherDescription: 'Habilita o deshabilita el acceso a la dimensión del Nether',
+  spawnProtection: 'Protección de Spawn',
+  spawnProtectionDescription: 'Radio (en bloques) alrededor del spawn que los no-operadores no pueden editar. Usa 0 para desactivar',
 
   // ===========================
   // PESTAÑA DE RENDIMIENTO

--- a/frontend/src/lib/translations/fr.ts
+++ b/frontend/src/lib/translations/fr.ts
@@ -527,6 +527,8 @@ export const fr = {
     'Définit si les structures comme les villages, temples, etc. seront générées',
   allowNether: 'Autoriser le Nether',
   allowNetherDescription: 'Activer ou désactiver l’accès à la dimension Nether',
+  spawnProtection: 'Protection du spawn',
+  spawnProtectionDescription: 'Rayon (en blocs) autour du spawn que les non-opérateurs ne peuvent pas modifier. Mettre 0 pour désactiver',
 
   // ===========================
   // PERFORMANCE SETTINGS TAB

--- a/frontend/src/lib/translations/nl.ts
+++ b/frontend/src/lib/translations/nl.ts
@@ -542,6 +542,8 @@ export const nl: Record<TranslationKey, string> = {
     'Bepaal of structuren zoals dorpen, tempels, etc. gegenereerd worden',
   allowNether: 'Nether toestaan',
   allowNetherDescription: 'Schakel toegang tot de Nether dimensie in of uit',
+  spawnProtection: 'Spawnbescherming',
+  spawnProtectionDescription: 'Straal (in blokken) rond de spawn die niet-ops niet kunnen bewerken. Zet op 0 om uit te schakelen',
 
   // ===========================
   // PRESTATIE INSTELLINGEN TAB

--- a/frontend/src/lib/translations/pl.ts
+++ b/frontend/src/lib/translations/pl.ts
@@ -523,6 +523,8 @@ export const pl: Record<TranslationKey, string> = {
     'Określ, czy struktury takie jak wioski, świątynie itp. będą generowane',
   allowNether: 'Zachowaj Nether',
   allowNetherDescription: 'Włącz lub wyłącz dostęp do wymiaru Nether',
+  spawnProtection: 'Ochrona spawnu',
+  spawnProtectionDescription: 'Promień (w blokach) wokół spawnu, którego nie-operatorzy nie mogą edytować. Ustaw 0, aby wyłączyć',
 
   // ===========================
   // STRONA: WYDAJNOŚĆ

--- a/frontend/src/lib/types/types.d.ts
+++ b/frontend/src/lib/types/types.d.ts
@@ -88,6 +88,7 @@ export interface ServerConfig {
   playerIdleTimeout: string;
   preventProxyConnections: boolean;
   opPermissionLevel: string;
+  spawnProtection: string;
 
   // RCON
   enableRcon: boolean;


### PR DESCRIPTION
## Summary

Triage of the currently open issues. Two code changes plus docs clarifications.

### `feat(server)`: configurable spawn protection (#142)
- New `spawnProtection` field on the server config, mapped to `SPAWN_PROTECTION` (Java only; Bedrock doesn't have it).
- UI: numeric input in **World settings → Spawning options** (default `16`, `0` disables).
- Added the key across all six translations and documented it in `doc/features.md`.

Closes #142.

### `feat(config)`: auto-detect host base dir (#143)
`BASE_DIR` is the host path that maps to `/app`; the generated server compose files and the chown helper use it to build host paths for the Docker daemon. If it didn't match the actual mount, servers landed in the wrong host folder.

Now it's auto-detected at startup from the real `Source` of the `/app/servers` bind (`docker inspect` on the own container, no new dependency). `BASE_DIR` env becomes a fallback for local/non-Docker runs; a mismatch is logged and the detected path wins. Docs (`configuration.md`, `troubleshooting.md`, `.env.example`, `backend/AGENTS.md`) updated accordingly.

Refs #143.

### `docs(curseforge)`: modpack URL vs server file (#138)
`AUTO_CURSEFORGE` expects the modpack (client) URL, not the server-files download. Clarified this and the `CF_EXCLUDE_MODS` workaround for client-only mods in `doc/mods-plugins.md`. No code change — it's expected itzg behavior.

Refs #138.

## Testing
- Backend: `build` OK, `173/173` tests pass, lint clean.
- Frontend: lint + build OK.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new spawn protection setting for Java servers, with a configurable radius and an option to disable it with `0`.
  * Improved server directory handling by automatically detecting the correct host folder at startup, reducing setup issues in Docker and local runs.

* **Documentation**
  * Updated configuration and troubleshooting docs to explain the new directory detection behavior.
  * Clarified modpack setup guidance for CurseForge sources and related install issues.

* **Bug Fixes**
  * Prevented server files from being written to the wrong host folder when directory settings don’t match the mounted path.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->