### PR TITLE
fix(i18n): correct backend URL env var name in connection error hint

### DIFF
--- a/frontend/src/lib/translations/de.ts
+++ b/frontend/src/lib/translations/de.ts
@@ -31,7 +31,7 @@ export const de: Record<TranslationKey, string> = {
   troubleshootingSteps: 'Fehlerbehebungsschritte',
   checkBackendUrl: 'Backend-URL überprüfen',
   checkBackendUrlDesc:
-    'Stellen Sie sicher, dass die NEXT_PUBLIC_API_URL Umgebungsvariable korrekt konfiguriert ist',
+    'Stellen Sie sicher, dass die NEXT_PUBLIC_BACKEND_URL Umgebungsvariable korrekt konfiguriert ist',
   checkServerRunning: 'Serverstatus überprüfen',
   checkServerRunningDesc:
     'Stellen Sie sicher, dass der Backend-Server läuft und auf dem konfigurierten Port erreichbar ist',

--- a/frontend/src/lib/translations/en.ts
+++ b/frontend/src/lib/translations/en.ts
@@ -29,7 +29,7 @@ export const en = {
   troubleshootingSteps: 'Troubleshooting Steps',
   checkBackendUrl: 'Check Backend URL',
   checkBackendUrlDesc:
-    'Verify that the NEXT_PUBLIC_API_URL environment variable is correctly configured',
+    'Verify that the NEXT_PUBLIC_BACKEND_URL environment variable is correctly configured',
   checkServerRunning: 'Verify Server Status',
   checkServerRunningDesc:
     'Ensure the backend server is running and accessible on the configured port',

--- a/frontend/src/lib/translations/es.ts
+++ b/frontend/src/lib/translations/es.ts
@@ -31,7 +31,7 @@ export const es: Record<TranslationKey, string> = {
   troubleshootingSteps: 'Pasos para Solucionar',
   checkBackendUrl: 'Verificar URL del Backend',
   checkBackendUrlDesc:
-    'Verifica que la variable de entorno NEXT_PUBLIC_API_URL esté correctamente configurada',
+    'Verifica que la variable de entorno NEXT_PUBLIC_BACKEND_URL esté correctamente configurada',
   checkServerRunning: 'Verificar Estado del Servidor',
   checkServerRunningDesc:
     'Asegúrate de que el servidor backend esté ejecutándose y accesible en el puerto configurado',

--- a/frontend/src/lib/translations/fr.ts
+++ b/frontend/src/lib/translations/fr.ts
@@ -29,7 +29,7 @@ export const fr = {
   troubleshootingSteps: 'Étapes de dépannage',
   checkBackendUrl: 'Vérifier l\'URL du backend',
   checkBackendUrlDesc:
-    "Vérifiez que la variable d'environnement NEXT_PUBLIC_API_URL est correctement configurée",
+    "Vérifiez que la variable d'environnement NEXT_PUBLIC_BACKEND_URL est correctement configurée",
   checkServerRunning: 'Vérifier l\'état du serveur',
   checkServerRunningDesc:
     "Assurez-vous que le serveur backend est en cours d'exécution et accessible sur le port configuré",

--- a/frontend/src/lib/translations/nl.ts
+++ b/frontend/src/lib/translations/nl.ts
@@ -31,7 +31,7 @@ export const nl: Record<TranslationKey, string> = {
   troubleshootingSteps: 'Probleemoplossingsstappen',
   checkBackendUrl: 'Controleer Backend URL',
   checkBackendUrlDesc:
-    'Verifieer dat de NEXT_PUBLIC_API_URL omgevingsvariabele correct is geconfigureerd',
+    'Verifieer dat de NEXT_PUBLIC_BACKEND_URL omgevingsvariabele correct is geconfigureerd',
   checkServerRunning: 'Controleer Server Status',
   checkServerRunningDesc:
     'Zorg ervoor dat de backend server draait en toegankelijk is op de geconfigureerde poort',

--- a/frontend/src/lib/translations/pl.ts
+++ b/frontend/src/lib/translations/pl.ts
@@ -31,7 +31,7 @@ export const pl: Record<TranslationKey, string> = {
   troubleshootingSteps: 'Kroki rozwiązywania problemów',
   checkBackendUrl: 'Sprawdź adres URL backendu',
   checkBackendUrlDesc:
-    'Upewnij się, że zmienna środowiskowa NEXT_PUBLIC_API_URL jest poprawnie skonfigurowana',
+    'Upewnij się, że zmienna środowiskowa NEXT_PUBLIC_BACKEND_URL jest poprawnie skonfigurowana',
   checkServerRunning: 'Sprawdź stan serwera',
   checkServerRunningDesc:
     'Upewnij się, że serwer backend działa i jest dostępny na skonfigurowanym porcie',


### PR DESCRIPTION
El texto de la tarjeta de "Connection error" indicaba `NEXT_PUBLIC_API_URL`, pero el frontend lee `NEXT_PUBLIC_BACKEND_URL` (`frontend/src/services/axios.service.ts` → `frontend/src/lib/public-env.ts`). El nombre obsoleto hacía que los usuarios configuraran la variable equivocada al autohospedar (ver #145).

Corregido el nombre de la variable en las 6 traducciones (`en, es, de, fr, pl, nl`).

Refs #145

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated troubleshooting text in multiple languages to reference the correct backend URL environment variable.
  * Improved consistency across help messages so users are guided to check `NEXT_PUBLIC_BACKEND_URL` instead of the old variable name.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->