### PR TITLE
feat(frontend): auto-select docker image tag from minecraft version

### DIFF
--- a/frontend/src/components/molecules/Tabs/ServerTypeTab.tsx
+++ b/frontend/src/components/molecules/Tabs/ServerTypeTab.tsx
@@ -27,6 +27,16 @@ interface ServerTypeTabProps {
 
 const OTHER_SERVER_TYPES: ServerType[] = ['NEOFORGE', 'CURSEFORGE', 'MODRINTH', 'GTNH', 'SPIGOT', 'PAPER', 'BUKKIT'];
 
+// Java requirements per Minecraft version (itzg/minecraft-server tags)
+const getSuggestedJavaImage = (mcVersion: string): string => {
+  if (!mcVersion || mcVersion.toLowerCase() === 'latest') return 'latest';
+  const [major, minor, patch] = mcVersion.split('.').map(Number);
+  if (major !== 1 || Number.isNaN(minor)) return 'latest';
+  if (minor <= 16) return 'java8';
+  if (minor < 20 || (minor === 20 && (patch || 0) <= 4)) return 'java17';
+  return 'java21';
+};
+
 export const ServerTypeTab: FC<ServerTypeTabProps> = ({ config, updateConfig }) => {
   const { t } = useLanguage();
   const edition = config.edition ?? 'JAVA';
@@ -41,9 +51,22 @@ export const ServerTypeTab: FC<ServerTypeTabProps> = ({ config, updateConfig }) 
   });
 
   const [showManualInput, setShowManualInput] = useState(false);
+  const [dockerImageMode, setDockerImageMode] = useState<'auto' | 'manual' | null>(null);
   const [serverTypeAccordion, setServerTypeAccordion] = useState<string | undefined>(
     OTHER_SERVER_TYPES.includes(config.serverType) ? 'others' : undefined,
   );
+
+  const suggestedDockerImage = getSuggestedJavaImage(config.minecraftVersion);
+  const dockerImageAuto = dockerImageMode
+    ? dockerImageMode === 'auto'
+    : !config.dockerImage || config.dockerImage === 'latest' || config.dockerImage === suggestedDockerImage;
+
+  useEffect(() => {
+    if (!isJava || isModpack || !dockerImageAuto) return;
+    if (config.dockerImage !== suggestedDockerImage) {
+      updateConfig('dockerImage', suggestedDockerImage);
+    }
+  }, [isJava, isModpack, dockerImageAuto, suggestedDockerImage, config.dockerImage, updateConfig]);
   const recommendedVersions = getRecommended();
 
   const filteredRecommendedVersions = recommendedVersions.filter((v) => v.id !== latestRelease);
@@ -374,32 +397,47 @@ export const ServerTypeTab: FC<ServerTypeTabProps> = ({ config, updateConfig }) 
                 <Image src="/images/barrier.webp" alt="Docker" width={16} height={16} />
                 {t('dockerImage')}
               </Label>
-              <TooltipProvider>
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <Button
-                      variant="ghost"
-                      size="icon"
-                      className="h-6 w-6 p-0 bg-transparent hover:bg-gray-700/50"
-                    >
-                      <HelpCircle className="h-4 w-4 text-gray-400" />
-                    </Button>
-                  </TooltipTrigger>
-                  <TooltipContent className="bg-gray-800 border-gray-700 text-gray-200">
-                    <p>{t('dockerImageDesc')}</p>
-                  </TooltipContent>
-                </Tooltip>
-              </TooltipProvider>
+              <div className="flex items-center gap-2">
+                <TooltipProvider>
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <Button
+                        variant="ghost"
+                        size="icon"
+                        className="h-6 w-6 p-0 bg-transparent hover:bg-gray-700/50"
+                      >
+                        <HelpCircle className="h-4 w-4 text-gray-400" />
+                      </Button>
+                    </TooltipTrigger>
+                    <TooltipContent className="bg-gray-800 border-gray-700 text-gray-200">
+                      <p>{t('dockerImageDesc')}</p>
+                    </TooltipContent>
+                  </Tooltip>
+                </TooltipProvider>
+                {!isModpack && (
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    className="h-6 text-xs bg-transparent hover:bg-gray-700/50 text-gray-300"
+                    onClick={() => setDockerImageMode(dockerImageAuto ? 'manual' : 'auto')}
+                  >
+                    {dockerImageAuto ? t('manual') : t('dockerImageAuto')}
+                  </Button>
+                )}
+              </div>
             </div>
             <Input
               id="dockerImage"
               value={config.dockerImage}
               onChange={(e) => updateConfig('dockerImage', e.target.value)}
               placeholder="java17"
-              className="bg-gray-800/70 text-gray-200 border-gray-700/50 focus:border-emerald-500/50 focus:ring-emerald-500/30"
+              disabled={!isModpack && dockerImageAuto}
+              className="bg-gray-800/70 text-gray-200 border-gray-700/50 focus:border-emerald-500/50 focus:ring-emerald-500/30 disabled:opacity-70"
             />
             <div className="space-y-1">
-              <p className="text-xs text-gray-400">{t('dockerImageHelp')}</p>
+              <p className="text-xs text-gray-400">
+                {!isModpack && dockerImageAuto ? t('dockerImageAutoHint') : t('dockerImageHelp')}
+              </p>
               <div className="flex items-center gap-2 p-2 bg-blue-900/30 border border-blue-700/50 rounded">
                 <div className="shrink-0">
                   <svg className="h-4 w-4 text-blue-400" fill="currentColor" viewBox="0 0 20 20">

--- a/frontend/src/lib/translations/de.ts
+++ b/frontend/src/lib/translations/de.ts
@@ -617,6 +617,8 @@ export const de: Record<TranslationKey, string> = {
   dockerImageHelp: 'Docker-Image verwenden (latest, java21, java17)',
   dockerImageHelpTags: 'Hier sind die verfügbaren Tags',
   dockerImageHelpDocumentation: 'Java-Version-Dokumentation',
+  dockerImageAuto: 'Auto',
+  dockerImageAutoHint: 'Wird automatisch anhand der Minecraft-Version ausgewählt',
   dockerVolumes: 'Docker-Volumes',
   dockerVolumesDesc: 'Zusätzliche Volume-Mappings für den Docker-Container',
   dockerVolumesHelp:

--- a/frontend/src/lib/translations/en.ts
+++ b/frontend/src/lib/translations/en.ts
@@ -613,6 +613,8 @@ export const en = {
   dockerImageHelp: 'Docker image to use (latest, java21, java17)',
   dockerImageHelpTags: 'Here are the available tags',
   dockerImageHelpDocumentation: 'Java version documentation',
+  dockerImageAuto: 'Auto',
+  dockerImageAutoHint: 'Selected automatically from the Minecraft version',
   dockerVolumes: 'Docker Volumes',
   dockerVolumesDesc: 'Additional volume mappings for the Docker container',
   dockerVolumesHelp: 'Docker volume mappings (one per line, format: local-path:container-path)',

--- a/frontend/src/lib/translations/es.ts
+++ b/frontend/src/lib/translations/es.ts
@@ -619,6 +619,8 @@ export const es: Record<TranslationKey, string> = {
   dockerImageHelp: 'Imagen Docker a utilizar (latest, java21, java17)',
   dockerImageHelpTags: 'Aquí están los tags disponibles',
   dockerImageHelpDocumentation: 'Documentación de versiones Java',
+  dockerImageAuto: 'Auto',
+  dockerImageAutoHint: 'Se selecciona automáticamente según la versión de Minecraft',
   dockerVolumes: 'Volúmenes Docker',
   dockerVolumesDesc: 'Mapeos adicionales de volúmenes para el contenedor Docker',
   dockerVolumesHelp:

--- a/frontend/src/lib/translations/fr.ts
+++ b/frontend/src/lib/translations/fr.ts
@@ -613,6 +613,8 @@ export const fr = {
   dockerImageHelp: 'Image Docker à utiliser (latest, java21, java17)',
   dockerImageHelpTags: 'Voici les tags disponibles',
   dockerImageHelpDocumentation: 'Documentation des versions Java',
+  dockerImageAuto: 'Auto',
+  dockerImageAutoHint: 'Sélectionnée automatiquement selon la version de Minecraft',
   dockerVolumes: 'Volumes Docker',
   dockerVolumesDesc: 'Mappages de volumes supplémentaires pour le conteneur Docker',
   dockerVolumesHelp: 'Mappages de volumes Docker (un par ligne, format : chemin-local:chemin-conteneur)',

--- a/frontend/src/lib/translations/nl.ts
+++ b/frontend/src/lib/translations/nl.ts
@@ -634,6 +634,8 @@ export const nl: Record<TranslationKey, string> = {
   dockerImageHelp: 'Docker image om te gebruiken (latest, java21, java17)',
   dockerImageHelpTags: 'Hier zijn de beschikbare tags',
   dockerImageHelpDocumentation: 'Java versie documentatie',
+  dockerImageAuto: 'Auto',
+  dockerImageAutoHint: 'Automatisch geselecteerd op basis van de Minecraft versie',
   dockerVolumes: 'Docker volumes',
   dockerVolumesDesc: 'Aanvullende volume mappings voor de Docker container',
   dockerVolumesHelp: 'Docker volume mappings (één per regel, formaat: lokaal-pad:container-pad)',

--- a/frontend/src/lib/translations/pl.ts
+++ b/frontend/src/lib/translations/pl.ts
@@ -611,6 +611,8 @@ export const pl: Record<TranslationKey, string> = {
   dockerImageHelp: 'Obraz Dockera do użycia (najnowszy, java21, java17)',
   dockerImageHelpTags: 'Oto dostępne tagi',
   dockerImageHelpDocumentation: 'Dokumentacja wersji Java',
+  dockerImageAuto: 'Auto',
+  dockerImageAutoHint: 'Wybierany automatycznie na podstawie wersji Minecraft',
   dockerVolumes: 'Woluminy Dockera',
   dockerVolumesDesc: 'Dodatkowe mapowania woluminów dla kontenera Dockera',
   dockerVolumesHelp:


### PR DESCRIPTION
## Summary
- Auto-select the `itzg/minecraft-server` image tag (Java version) based on the selected Minecraft version in `ServerTypeTab`, with an Auto/Manual toggle.
- Mapping (per [itzg Java version docs](https://docker-minecraft-server.readthedocs.io/en/latest/versions/java/)): `latest` → `latest`, ≤1.16.x → `java8`, 1.17–1.20.4 → `java17`, ≥1.20.5 → `java21`. Unparseable versions fall back to `latest`.
- Initial mode is inferred: empty/`latest`/already-matching values start in Auto; custom values (e.g. `java17-graalvm`) start in Manual so existing configs are never overwritten.
- Modpack types (AUTO_CURSEFORGE, CURSEFORGE, MODRINTH, GTNH) keep the manual input only, since the modpack dictates the MC version.
- New i18n keys `dockerImageAuto` / `dockerImageAutoHint` added to all 6 dictionaries.

Frontend-only: the backend still receives a concrete tag; no API changes.

## Test plan
- [ ] Create a Java server, pick MC 1.20.6 → docker image auto-sets to `java21`; 1.16.5 → `java8`; 1.18 → `java17`.
- [ ] Toggle to Manual → input editable, version changes no longer touch it.
- [ ] Open an existing server with a custom image tag → starts in Manual, value untouched.
- [ ] Modpack types and Bedrock unaffected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an automatic Docker image selection option based on the chosen Minecraft version.
  * Updated the Docker image setting to switch between auto and manual modes, with auto-selection disabled for modpacks.

* **Bug Fixes**
  * The suggested image tag now updates when the selected version changes, helping keep the configuration aligned.

* **Documentation**
  * Added translated labels and helper text for the new auto-selection option in multiple languages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->