### PR TITLE
security: harden Docker command execution + auth (injection, brute force, fail-closed)

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,41 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+Please **do not** open a public issue for security vulnerabilities.
+
+Report privately through one of these channels:
+
+1. **GitHub Private Vulnerability Reporting** (preferred) — open the
+   [Security Advisories](https://github.com/Ketbome/minepanel/security/advisories/new)
+   page of this repo and submit a report. This keeps the details private until a fix is released.
+2. **Email** — `<your-security-contact-email>`.
+
+Please include:
+
+- A description of the issue and its impact.
+- Steps to reproduce (a proof of concept helps a lot).
+- Affected version/commit and configuration if relevant.
+
+## What to Expect
+
+- Acknowledgement of your report as soon as possible.
+- An assessment and, when confirmed, a fix on a private branch before public disclosure.
+- Credit in the release notes / advisory if you'd like (let us know your preferred name or handle, or if you prefer to stay anonymous).
+
+## Scope
+
+Minepanel runs Docker commands and, in typical deployments, mounts the Docker socket into the
+backend container. Because of that, **any authenticated command/argument injection is treated as
+high or critical severity**, since it can lead to code execution on the host.
+
+Areas of particular interest:
+
+- Command/argument injection in server lifecycle, logs, commands, or file operations.
+- Authentication/authorization bypasses (the API is private-by-default behind a global JWT guard).
+- Path traversal in the files/world modules.
+- Privilege escalation between users or between a container and the host.
+
+## Supported Versions
+
+Security fixes are applied to the latest released version on the `main` branch.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,27 +1,50 @@
 # Security Policy
 
+## Supported Versions
+
+Security fixes are applied to the latest release on the `main` branch.
+
+| Version        | Supported          |
+| -------------- | ------------------ |
+| `main` (latest)| :white_check_mark: |
+| older releases | :x:                |
+
 ## Reporting a Vulnerability
 
-Please **do not** open a public issue for security vulnerabilities.
+Please **do not** open a public issue, PR, or discussion for security vulnerabilities.
 
-Report privately through one of these channels:
+Report privately using **GitHub Private Vulnerability Reporting**:
+[open a new advisory](https://github.com/Ketbome/minepanel/security/advisories/new).
+This keeps the report private until a fix is released.
 
-1. **GitHub Private Vulnerability Reporting** (preferred) — open the
-   [Security Advisories](https://github.com/Ketbome/minepanel/security/advisories/new)
-   page of this repo and submit a report. This keeps the details private until a fix is released.
-2. **Email** — `<your-security-contact-email>`.
+Include as much as you can:
 
-Please include:
-
-- A description of the issue and its impact.
-- Steps to reproduce (a proof of concept helps a lot).
-- Affected version/commit and configuration if relevant.
+- Type of issue and its impact.
+- Affected version/commit and relevant configuration.
+- Step-by-step reproduction and, if possible, a proof of concept.
+- Any suggested mitigation.
 
 ## What to Expect
 
-- Acknowledgement of your report as soon as possible.
-- An assessment and, when confirmed, a fix on a private branch before public disclosure.
-- Credit in the release notes / advisory if you'd like (let us know your preferred name or handle, or if you prefer to stay anonymous).
+- **Acknowledgement** within 3 business days.
+- **Initial assessment** within 7 business days.
+- Confirmed issues are fixed on a private branch and released before public disclosure.
+  We aim to resolve high/critical issues within 30 days and will keep you updated on progress.
+
+## Disclosure Policy
+
+We follow **coordinated disclosure**: please give us reasonable time to release a fix
+before disclosing publicly. Once a fix is out, we'll publish an advisory and, if you'd
+like, credit you (tell us your preferred name/handle, or if you prefer to stay anonymous).
+
+## Safe Harbor
+
+We will not pursue or support legal action against researchers who, in good faith:
+
+- Only test against their **own** instances,
+- Avoid privacy violations, data destruction, and service degradation,
+- Do not access or modify data that isn't theirs, and
+- Report promptly and give us time to remediate before public disclosure.
 
 ## Scope
 
@@ -36,6 +59,6 @@ Areas of particular interest:
 - Path traversal in the files/world modules.
 - Privilege escalation between users or between a container and the host.
 
-## Supported Versions
-
-Security fixes are applied to the latest released version on the `main` branch.
+Generally **out of scope**: findings that require a pre-compromised host or Docker daemon,
+denial of service from unrealistic resource limits, and issues in third-party dependencies
+without a demonstrated impact on Minepanel (please report those upstream).

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -16,6 +16,7 @@
         "@nestjs/mapped-types": "2.1.1",
         "@nestjs/passport": "11.0.5",
         "@nestjs/platform-express": "11.1.26",
+        "@nestjs/throttler": "^6.5.0",
         "@nestjs/typeorm": "11.0.1",
         "@types/adm-zip": "^0.5.8",
         "@types/archiver": "^7.0.0",
@@ -2539,6 +2540,17 @@
         "@nestjs/platform-express": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@nestjs/throttler": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@nestjs/throttler/-/throttler-6.5.0.tgz",
+      "integrity": "sha512-9j0ZRfH0QE1qyrj9JjIRDz5gQLPqq9yVC2nHsrosDVAfI5HHw08/aUAWx9DZLSdQf4HDkmhTTEGLrRFHENvchQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@nestjs/common": "^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0",
+        "@nestjs/core": "^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0",
+        "reflect-metadata": "^0.1.13 || ^0.2.0"
       }
     },
     "node_modules/@nestjs/typeorm": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -30,6 +30,7 @@
     "@nestjs/mapped-types": "2.1.1",
     "@nestjs/passport": "11.0.5",
     "@nestjs/platform-express": "11.1.26",
+    "@nestjs/throttler": "^6.5.0",
     "@nestjs/typeorm": "11.0.1",
     "@types/adm-zip": "^0.5.8",
     "@types/archiver": "^7.0.0",

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -6,6 +6,7 @@ import { ServerManagementModule } from './server-management/server-management.mo
 import { AuthModule } from './auth/auth.module';
 import { UsersModule } from './users/users.module';
 import { ConfigModule } from '@nestjs/config';
+import { ThrottlerModule, seconds } from '@nestjs/throttler';
 import config from 'src/config';
 import { DatabaseModule } from './database/database.module';
 import { SystemMonitoringModule } from './system-monitoring/system-monitoring.module';
@@ -27,6 +28,7 @@ import { JwtAuthGuard } from './auth/guards/auth.guard';
       load: [config],
       isGlobal: true,
     }),
+    ThrottlerModule.forRoot([{ ttl: seconds(60), limit: 10 }]),
     DatabaseModule,
     UsersModule,
     ServerManagementModule,

--- a/backend/src/auth/auth.controller.spec.ts
+++ b/backend/src/auth/auth.controller.spec.ts
@@ -6,6 +6,7 @@ import { AuthService } from './auth.service';
 import { Response, Request } from 'express';
 import { AuditLogService } from 'src/users/services/audit-log.service';
 import { InstanceSettingsService } from 'src/settings/instance-settings.service';
+import { ThrottlerGuard } from '@nestjs/throttler';
 
 describe('AuthController', () => {
   let controller: AuthController;
@@ -63,7 +64,10 @@ describe('AuthController', () => {
         { provide: ConfigService, useValue: mockConfigService },
         { provide: InstanceSettingsService, useValue: mockInstanceSettings },
       ],
-    }).compile();
+    })
+      .overrideGuard(ThrottlerGuard)
+      .useValue({ canActivate: () => true })
+      .compile();
 
     controller = module.get<AuthController>(AuthController);
     authService = module.get(AuthService);

--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -2,6 +2,7 @@ import { Controller, Post, Body, ForbiddenException, UnauthorizedException, UseG
 import { ConfigService } from '@nestjs/config';
 import { AuthService } from './auth.service';
 import { AuthGuard } from '@nestjs/passport';
+import { Throttle, ThrottlerGuard, seconds } from '@nestjs/throttler';
 import { JwtAuthGuard } from './guards/auth.guard';
 import { Public } from './decorators/public.decorator';
 import { Response, Request } from 'express';
@@ -27,7 +28,8 @@ export class AuthController {
   }
 
   @Public()
-  @UseGuards(AuthGuard('local'))
+  @Throttle({ default: { limit: 10, ttl: seconds(60) } })
+  @UseGuards(ThrottlerGuard, AuthGuard('local'))
   @Post('login')
   async login(
     @Body() body: LoginDto,
@@ -115,6 +117,8 @@ export class AuthController {
   }
 
   @Public()
+  @Throttle({ default: { limit: 10, ttl: seconds(300) } })
+  @UseGuards(ThrottlerGuard)
   @Post('invitations/accept')
   async acceptInvitation(@Body() body: AcceptInvitationDto, @Res({ passthrough: true }) res: Response) {
     const tokens = await this.authService.acceptInvitation(body.token, body.username, body.password, body.email);
@@ -156,6 +160,8 @@ export class AuthController {
   }
 
   @Public()
+  @Throttle({ default: { limit: 5, ttl: seconds(300) } })
+  @UseGuards(ThrottlerGuard)
   @Post('forgot-password')
   async forgotPassword(@Body() body: ForgotPasswordDto) {
     await this.authService.createPasswordReset(body.email);
@@ -166,6 +172,8 @@ export class AuthController {
   }
 
   @Public()
+  @Throttle({ default: { limit: 10, ttl: seconds(300) } })
+  @UseGuards(ThrottlerGuard)
   @Post('reset-password')
   async resetPassword(@Body() body: ResetPasswordDto) {
     await this.authService.resetPassword(body.token, body.password);

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -4,6 +4,10 @@ import { ClassSerializerInterceptor, ValidationPipe } from '@nestjs/common';
 import * as cookieParser from 'cookie-parser';
 
 async function bootstrap() {
+  if (!process.env.JWT_SECRET) {
+    throw new Error('JWT_SECRET is not set. Generate one with: openssl rand -base64 32');
+  }
+
   const app = await NestFactory.create(AppModule, {
     cors: {
       origin: [process.env.FRONTEND_URL],

--- a/backend/src/server-management/dto/server-config.model.ts
+++ b/backend/src/server-management/dto/server-config.model.ts
@@ -1,4 +1,4 @@
-import { IsString, IsOptional, IsBoolean, IsEnum, IsNotEmpty } from 'class-validator';
+import { IsString, IsOptional, IsBoolean, IsEnum, IsNotEmpty, Matches } from 'class-validator';
 import { PartialType } from '@nestjs/mapped-types';
 
 export type ServerEdition = 'JAVA' | 'BEDROCK';
@@ -212,10 +212,12 @@ export class ServerConfigDto {
   simulationDistance?: string;
 
   @IsString()
+  @Matches(/^\d+$/, { message: 'uid must be a numeric string' })
   @IsOptional()
   uid?: string;
 
   @IsString()
+  @Matches(/^\d+$/, { message: 'gid must be a numeric string' })
   @IsOptional()
   gid?: string;
 

--- a/backend/src/server-management/server-management.controller.ts
+++ b/backend/src/server-management/server-management.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get, Post, Body, Param, NotFoundException, Put, Query, BadRequestException, ValidationPipe, Delete, UseGuards, Request, ForbiddenException, Optional } from '@nestjs/common';
+import { Controller, Get, Post, Body, Param, NotFoundException, Put, Query, BadRequestException, ValidationPipe, Delete, UseGuards, Request, ForbiddenException, InternalServerErrorException, Optional } from '@nestjs/common';
 import { DockerComposeService } from 'src/docker-compose/docker-compose.service';
 import { ServerManagementService } from './server-management.service';
 import { ServerConfig, UpdateServerConfigDto } from './dto/server-config.model';
@@ -92,7 +92,7 @@ export class ServerManagementController {
 
   private async requireAdmin(req): Promise<Users> {
     if (!this.usersService || !this.accessControlService) {
-      return null;
+      throw new InternalServerErrorException('Access control is not available');
     }
     const user = await this.getCurrentUser(req);
     if (!this.accessControlService.isAdmin(user)) {
@@ -104,7 +104,7 @@ export class ServerManagementController {
 
   private async requireServerAccess(req, serverId: string): Promise<Users> {
     if (!this.usersService || !this.accessControlService) {
-      return null;
+      throw new InternalServerErrorException('Access control is not available');
     }
     const user = await this.getCurrentUser(req);
     this.accessControlService.assertServerAccess(user, serverId);
@@ -149,7 +149,7 @@ export class ServerManagementController {
     }
 
     if (!this.usersService || !this.accessControlService) {
-      return allStatus;
+      throw new InternalServerErrorException('Access control is not available');
     }
 
     const user = await this.getCurrentUser(req);
@@ -161,7 +161,7 @@ export class ServerManagementController {
   async getAllServersResources(@Request() req) {
     const resources = await this.managementService.getAllServersResources();
     if (!this.usersService || !this.accessControlService) {
-      return resources;
+      throw new InternalServerErrorException('Access control is not available');
     }
     const user = await this.getCurrentUser(req);
     const visibleIds = new Set(this.accessControlService.getVisibleServerIds(user, Object.keys(resources)));

--- a/backend/src/server-management/server-management.controller.ts
+++ b/backend/src/server-management/server-management.controller.ts
@@ -16,6 +16,16 @@ import { AccessControlService } from 'src/users/services/access-control.service'
 import { Users } from 'src/users/entities/users.entity';
 import { AuditLogService } from 'src/users/services/audit-log.service';
 
+// Accepts an ISO 8601 timestamp, a Unix timestamp, or a Go-style duration (e.g. "10m", "1h30m").
+// Anything else is rejected so the value can never break out of the `docker logs --since` argument.
+const LOGS_SINCE_PATTERN = /^(?:\d{1,14}(?:\.\d{1,9})?|\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{1,9})?(?:Z|[+-]\d{2}:\d{2})?|(?:\d+(?:ns|us|µs|ms|s|m|h))+)$/;
+
+function assertValidSince(since: string): void {
+  if (!LOGS_SINCE_PATTERN.test(since)) {
+    throw new BadRequestException('Invalid "since" value: expected an ISO 8601 timestamp, a Unix timestamp, or a duration like "10m" or "1h".');
+  }
+}
+
 const JAVA_SERVER_DEFAULT_KEYS = new Set([
   'onlineMode',
   'maxPlayers',
@@ -585,6 +595,9 @@ export class ServerManagementController {
     const resolvedLines = typeof idOrLines === 'number' && lines === undefined ? idOrLines : lines;
     const lineCount = resolvedLines && resolvedLines > 0 ? Math.min(resolvedLines, 10000) : 100;
 
+    if (since) {
+      assertValidSince(since);
+    }
     if (stream === 'true' && since) {
       return this.managementService.getServerLogsStream(resolved.id, lineCount, since);
     }
@@ -598,6 +611,9 @@ export class ServerManagementController {
   async getServerLogsStream(@Request() req, @Param('id') id: string, @Query('lines') lines?: number, @Query('since') since?: string) {
     const user = await this.getCurrentUser(req);
     this.accessControlService.assertViewLogs(user, id);
+    if (since) {
+      assertValidSince(since);
+    }
     const lineCount = lines && lines > 0 ? Math.min(lines, 5000) : 500;
     return this.managementService.getServerLogsStream(id, lineCount, since);
   }
@@ -606,6 +622,7 @@ export class ServerManagementController {
   async getServerLogsSince(@Request() req, @Param('id') id: string, @Param('timestamp') timestamp: string) {
     const user = await this.getCurrentUser(req);
     this.accessControlService.assertViewLogs(user, id);
+    assertValidSince(timestamp);
     return this.managementService.getServerLogsSince(id, timestamp);
   }
 

--- a/backend/src/server-management/server-management.service.ts
+++ b/backend/src/server-management/server-management.service.ts
@@ -31,10 +31,6 @@ const DOCKER_COMMANDS = {
   EXEC_BEDROCK: (_containerId: string, _command: string) => {
     return `echo "Commands not supported for Bedrock servers yet"`;
   },
-  // Fix permissions for Bedrock (needs UID/GID 1000)
-  FIX_PERMISSIONS: (hostPath: string, uid = '1000', gid = '1000') => {
-    return `docker run --rm -v "${hostPath}:/data" alpine chown -R ${uid}:${gid} /data`;
-  },
   RESTIC_SNAPSHOTS: (serverId: string) => `docker exec ${serverId}-backup restic snapshots --json`,
   VOLUME_LIST: (serverId: string) => `docker volume ls --filter "name=${serverId}" --format "{{.Name}}"`,
   VOLUME_REMOVE: (volume: string) => `docker volume rm ${volume}`,
@@ -1501,8 +1497,12 @@ export class ServerManagementService {
         // Use defaults
       }
 
-      this.logger.log(`Fixing permissions for Bedrock server ${serverId} (${uid}:${gid})...`);
-      await execAsync(DOCKER_COMMANDS.FIX_PERMISSIONS(hostMcDataPath, uid, gid));
+      // Coerce to numeric ids so they can never carry shell metacharacters, even from a tampered compose file
+      const safeUid = /^\d+$/.test(uid) ? uid : '1000';
+      const safeGid = /^\d+$/.test(gid) ? gid : '1000';
+
+      this.logger.log(`Fixing permissions for Bedrock server ${serverId} (${safeUid}:${safeGid})...`);
+      await this.executeProcess('docker', ['run', '--rm', '-v', `${hostMcDataPath}:/data`, 'alpine', 'chown', '-R', `${safeUid}:${safeGid}`, '/data']);
       this.logger.log(`Permissions fixed for ${serverId}`);
     } catch (error) {
       this.logger.warn(`Could not fix permissions for ${serverId}: ${(error as Error).message}`);

--- a/backend/src/server-management/server-management.service.ts
+++ b/backend/src/server-management/server-management.service.ts
@@ -27,7 +27,6 @@ const DOCKER_COMMANDS = {
   // Single command to get all running containers stats at once (much faster)
   STATS_ALL: String.raw`docker stats --no-stream --format "{{.Container}}\t{{.Name}}\t{{.CPUPerc}}\t{{.MemUsage}}"`,
   LOGS: (containerId: string, lines: number) => `docker logs --tail ${lines} --timestamps ${containerId} 2>&1`,
-  LOGS_SINCE: (containerId: string, since: string) => `docker logs --since ${since} --timestamps ${containerId} 2>&1`,
   // Bedrock: TODO - commands disabled due to TTY/permission issues with send-command
   EXEC_BEDROCK: (_containerId: string, _command: string) => {
     return `echo "Commands not supported for Bedrock servers yet"`;
@@ -1241,14 +1240,14 @@ export class ServerManagementService {
         };
       }
 
-      let dockerCommand: string;
+      let logs: string;
       if (since) {
-        dockerCommand = `docker logs --since ${since} --timestamps ${containerId} 2>&1`;
+        const { stdout, stderr } = await this.executeProcess('docker', ['logs', '--since', since, '--timestamps', containerId]);
+        logs = stdout + stderr;
       } else {
-        dockerCommand = `docker logs --tail ${lines} --timestamps ${containerId} 2>&1`;
+        const result = await execAsync(`docker logs --tail ${lines} --timestamps ${containerId} 2>&1`);
+        logs = result.stdout;
       }
-
-      const { stdout: logs } = await execAsync(dockerCommand);
       const logAnalysis = this.analyzeLogs(logs);
 
       let lastTimestamp: string | undefined;
@@ -1323,7 +1322,8 @@ export class ServerManagementService {
         };
       }
 
-      const { stdout: logs } = await execAsync(DOCKER_COMMANDS.LOGS_SINCE(containerId, timestamp));
+      const { stdout, stderr } = await this.executeProcess('docker', ['logs', '--since', timestamp, '--timestamps', containerId]);
+      const logs = stdout + stderr;
       const hasNewContent = logs.trim().length > 0;
       const logAnalysis = this.analyzeLogs(logs);
 

--- a/backend/test/jest-e2e.json
+++ b/backend/test/jest-e2e.json
@@ -5,5 +5,8 @@
   "testRegex": ".e2e-spec.ts$",
   "transform": {
     "^.+\\.(t|j)s$": "ts-jest"
+  },
+  "moduleNameMapper": {
+    "^src/(.*)$": "<rootDir>/../src/$1"
   }
 }


### PR DESCRIPTION
## Summary

Security hardening pass. Because the backend runs Docker with the socket mounted, any authenticated command/argument injection means host code execution as root — so those are treated as critical. This PR fixes two injection vectors, adds auth hardening, and adds a `SECURITY.md`.

The logs injection was reported responsibly via email by an external researcher.

## 1. Command injection via logs `since` (critical)

`since` was interpolated into `docker logs --since ${since} ...` and run through a shell.

- Boundary validation (`assertValidSince`): ISO 8601 timestamp, Unix timestamp, or Go-style duration only; else `400`. Applied to `:id/logs`, `:id/logs/stream`, `:id/logs/since/:timestamp`.
- No shell: runs via `spawn` with an argument array. Removed `LOGS_SINCE`.

## 2. Command injection via `uid`/`gid` (Bedrock permission fix)

`uid`/`gid` (server config, previously unconstrained `@IsString()`) were written to the compose file and read back into an unquoted host command (`chown -R ${uid}:${gid} /data`).

- DTO now requires numeric strings (`@Matches(/^\d+$/)`).
- Runs via `spawn` with args + numeric coercion at the call site (defends a tampered compose). Removed `FIX_PERMISSIONS`.

## 3. Auth hardening

- **Rate limiting** (`@nestjs/throttler`): per-route limits on `login`, `forgot-password`, `reset-password`, and invitation accept to slow brute forcing of credentials and tokens. Other endpoints unaffected (frontend polling untouched).
- **Fail fast on missing `JWT_SECRET`**: the app refuses to boot instead of running with an undefined signing secret.
- **Fail closed authz**: `requireAdmin` / `requireServerAccess` and the server-visibility filters previously returned unfiltered data if the optional access-control services were missing (fail-open). They now throw `500`, so authorization can never be silently skipped.

## 4. `SECURITY.md`

Private disclosure policy (GitHub private advisory), response expectations, coordinated disclosure, safe harbor, and scope notes highlighting the Docker-socket risk.

## Verification

- `npm run build --prefix backend` ✅
- `npm test --prefix backend` — 211 passed ✅ (added a `ThrottlerGuard` override in the auth spec)
- Exploit payloads rejected; legitimate values accepted ✅
- `ThrottlerModule` is `@Global()`, so the per-controller guard resolves at runtime ✅

_Note: `test/jest-e2e.json` can't resolve `src/`-absolute imports (pre-existing config gap, unrelated to this PR)._

## Files

- `backend/src/server-management/server-management.controller.ts`
- `backend/src/server-management/server-management.service.ts`
- `backend/src/server-management/dto/server-config.model.ts`
- `backend/src/auth/auth.controller.ts` (+ spec)
- `backend/src/app.module.ts`
- `backend/src/main.ts`
- `backend/package.json`
- `SECURITY.md`