### PR TITLE
fix(ports): Persist default server port

### DIFF
--- a/backend/src/docker-compose/docker-compose.service.spec.ts
+++ b/backend/src/docker-compose/docker-compose.service.spec.ts
@@ -208,6 +208,20 @@ describe('DockerComposeService', () => {
       expect(config.motd).toBe('An incredible Minecraft server');
     });
 
+    it('should persist the default port when the configured port is empty', async () => {
+      const config = (service as any).createDefaultConfig('default-port');
+      config.port = '';
+
+      await service.generateDockerComposeFile(config, false);
+
+      const writeFileMock = fs.writeFile as unknown as jest.Mock;
+      const [, yamlContent] = writeFileMock.mock.calls[0];
+      const parsed = yaml.load(yamlContent as string) as any;
+
+      expect(parsed.services.mc.ports).toContain('25565:25565');
+      expect(config.port).toBe('25565');
+    });
+
     it('should generate mc service without container_name', async () => {
       const config = (service as any).createDefaultConfig('survival');
 

--- a/backend/src/docker-compose/docker-compose.service.ts
+++ b/backend/src/docker-compose/docker-compose.service.ts
@@ -1222,9 +1222,7 @@ export class DockerComposeService {
     const reserveProxyPort = (config.edition ?? 'JAVA') === 'JAVA' && !usesProxy && (proxyEnabled || await this.isMcRouterRunning());
     const reservedPorts = reserveProxyPort ? [Number.parseInt(defaultPort)] : [];
     const availablePort = await this.findAvailablePort(requestedPort, config.id, reservedPorts);
-    if (availablePort !== requestedPort) {
-      config.port = availablePort.toString();
-    }
+    config.port = availablePort.toString();
     return config.port;
   }
 


### PR DESCRIPTION
## Description

Persist the selected default port when `config.port` is empty.

Previously, an empty port produced a Docker mapping like `:25565`, which made
Docker assign a random host port. The generated Compose file now uses
`25565:25565` and saves `25565` back to the configuration.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update
- [ ] 🔧 Configuration change
- [ ] ♻️ Refactoring (no functional changes)
- [x] 🧪 Tests

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have tested my changes locally
- [ ] I have updated documentation if needed
- [x] My changes don't introduce new warnings or errors

## Screenshots (if applicable)

Not applicable.

## Related Issues

None.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved server port handling when no port is specified.
  * Ensures the default port `25565` is consistently applied in generated Docker configurations and server settings.
  * Prevents mismatches between the configured port and the port actually made available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->