### PR TITLE
fix(clone): remap volume host paths to the cloned server id

### DIFF
--- a/backend/src/docker-compose/docker-compose.service.ts
+++ b/backend/src/docker-compose/docker-compose.service.ts
@@ -1201,6 +1201,28 @@ export class DockerComposeService {
     return [host, target, ...options].join(':');
   }
 
+  remapVolumesToServer(dockerVolumes: string | undefined, sourceId: string, targetId: string): string | undefined {
+    if (!dockerVolumes) return dockerVolumes;
+
+    return dockerVolumes
+      .split('\n')
+      .map((line) => {
+        const volume = line.trim();
+        if (!volume) return line;
+
+        const [hostPath, ...containerParts] = volume.split(':');
+        if (containerParts.length === 0 || hostPath.startsWith('./')) return line;
+
+        const segments = hostPath.split('/');
+        const serverIdIndex = segments.findIndex((segment, index) => segment === 'servers' && segments[index + 1] === sourceId);
+        if (serverIdIndex === -1) return line;
+
+        segments[serverIdIndex + 1] = targetId;
+        return `${segments.join('/')}:${containerParts.join(':')}`;
+      })
+      .join('\n');
+  }
+
   private hasMountTarget(volume: string, target: string): boolean {
     const parts = volume.split(':');
     if (parts.length < 2) return false;

--- a/backend/src/server-management/server-management.controller.ts
+++ b/backend/src/server-management/server-management.controller.ts
@@ -271,6 +271,7 @@ export class ServerManagementController {
       extraPorts: [],
       proxyHostname: undefined,
       backupHostDir: undefined,
+      dockerVolumes: this.dockerComposeService.remapVolumesToServer(config.dockerVolumes, id, body.newId),
     };
     if (config.worldScope === 'local' && config.worldSource) {
       clonePayload.worldSource = '';


### PR DESCRIPTION
Closes #170

## Problem

Cloning a server copies the source config as-is. `dockerVolumes` is loaded from the source `docker-compose.yml` as **absolute host paths** (`backend/src/docker-compose/docker-compose.service.ts:235`), and `parseVolumes` only rewrites entries starting with `./`. So the clone's compose kept pointing at the source directories and both servers shared the same data.

## Fix

- `DockerComposeService.remapVolumesToServer()`: rewrites the `servers/<sourceId>` segment of each volume host path to `servers/<newId>`. Relative (`./`) and named volumes are left untouched, and the global library mount (`servers/.world/worlds`) stays shared, as intended.
- The clone endpoint (`server-management.controller.ts:245`) runs the source `dockerVolumes` through it before calling `createServer`.

## Result

Cloning `atm9tts` into `atm9tts-clone` now generates:

```yaml
volumes:
  - /game/minepanel/servers/atm9tts-clone/mc-data:/data
  - /game/minepanel/servers/atm9tts-clone/modpacks:/modpacks:ro
  - /game/minepanel/servers/atm9tts-clone/worlds:/data/.world-library/local:ro
  - /game/minepanel/servers/.world/worlds:/data/.world-library/global:ro
```

## Checks

- `npx tsc --noEmit` clean
- `npm test --prefix backend`: 25 suites / 212 tests passing
- `eslint` clean on both changed files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved server cloning so Docker volume paths are correctly updated for the new server.
  * Preserved container paths, mount options, relative paths, and unmatched volume definitions during cloning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->