### PR TITLE
fix(frontend): make the first render deterministic to stop hydration crashes

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -74,7 +74,7 @@ NEXT_PUBLIC_BASE_PATH=                        # Optional frontend prefix, e.g. /
 # -----------------------------------------------------------------------------
 # Language
 # -----------------------------------------------------------------------------
-NEXT_PUBLIC_DEFAULT_LANGUAGE=en               # Options: en, es, nl, de, pl
+NEXT_PUBLIC_DEFAULT_LANGUAGE=en               # Options: en, es, nl, de, pl, fr, ru, pt
 
 # =============================================================================
 # Configuration Examples

--- a/doc/troubleshooting.md
+++ b/doc/troubleshooting.md
@@ -181,7 +181,7 @@ sudo ufw allow 3000/tcp
 **Solutions:**
 
 1. Update to the latest Minepanel version. The panel now declares itself as non-translatable and its first render no longer depends on runtime settings.
-2. Disable automatic translation for the panel (Chrome: right click → **Translate to...** → **Never translate this site**).
+2. Disable automatic translation for the panel (Chrome: right-click → **Translate to...** → **Never translate this site**).
 3. Retry in a private window with extensions disabled to confirm the cause.
 4. Hard refresh with `Ctrl+Shift+R` after updating.
 

--- a/doc/troubleshooting.md
+++ b/doc/troubleshooting.md
@@ -172,6 +172,19 @@ curl http://localhost:3000
 sudo ufw allow 3000/tcp
 ```
 
+### Blank page or "Application error" while navigating
+
+**Symptoms:** A page fails to render (blank screen or a client-side exception) and DevTools shows a React hydration error (`#418`) followed by `NotFoundError: Failed to execute 'insertBefore' on 'Node'`. Usually only in one browser.
+
+**Cause:** Something rewrote the page HTML before React took over. The two known sources are the browser's automatic page translation and extensions that inject content into the page.
+
+**Solutions:**
+
+1. Update to the latest Minepanel version. The panel now declares itself as non-translatable and its first render no longer depends on runtime settings.
+2. Disable automatic translation for the panel (Chrome: right click → **Translate to...** → **Never translate this site**).
+3. Retry in a private window with extensions disabled to confirm the cause.
+4. Hard refresh with `Ctrl+Shift+R` after updating.
+
 ### Can't Access from Remote
 
 **Symptoms:** Works on `localhost` but not from other devices

--- a/frontend/src/app/error.tsx
+++ b/frontend/src/app/error.tsx
@@ -1,0 +1,39 @@
+'use client';
+
+import { useEffect } from 'react';
+import { AlertCircle, RefreshCw } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { useLanguage } from '@/lib/hooks/useLanguage';
+
+export default function Error({ error, reset }: { readonly error: Error & { digest?: string }; readonly reset: () => void }) {
+  const { t } = useLanguage();
+
+  useEffect(() => {
+    console.error(error);
+  }, [error]);
+
+  return (
+    <div className="flex min-h-screen mp-blueprint items-center justify-center p-6">
+      <div className="max-w-lg w-full bg-gray-900/95 border-2 border-red-600/40 rounded-lg p-6 text-center">
+        <div className="w-16 h-16 rounded-full bg-red-600/20 flex items-center justify-center mx-auto mb-4">
+          <AlertCircle className="w-8 h-8 text-red-400" />
+        </div>
+        <h1 className="text-2xl font-minecraft text-red-400 mb-2">{t('unexpectedError')}</h1>
+        <p className="text-sm text-gray-300 mb-6">{t('unexpectedErrorDesc')}</p>
+        <div className="flex flex-col sm:flex-row gap-2 justify-center">
+          <Button onClick={reset} className="bg-emerald-600 hover:bg-emerald-700 text-white font-minecraft">
+            <RefreshCw className="w-4 h-4 mr-2" />
+            {t('retry')}
+          </Button>
+          <Button
+            onClick={() => window.location.reload()}
+            variant="ghost"
+            className="text-gray-300 hover:text-white hover:bg-gray-800"
+          >
+            {t('reloadPage')}
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/app/global-error.tsx
+++ b/frontend/src/app/global-error.tsx
@@ -1,0 +1,50 @@
+'use client';
+
+import { useEffect } from 'react';
+
+// Replaces the root layout, so it cannot use providers or global styles.
+export default function GlobalError({ error, reset }: { readonly error: Error & { digest?: string }; readonly reset: () => void }) {
+  useEffect(() => {
+    console.error(error);
+  }, [error]);
+
+  return (
+    <html lang="en" translate="no">
+      <body
+        style={{
+          margin: 0,
+          minHeight: '100vh',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          background: '#0b0f14',
+          color: '#e5e7eb',
+          fontFamily: 'system-ui, sans-serif',
+          padding: '24px',
+        }}
+      >
+        <div style={{ maxWidth: '32rem', textAlign: 'center' }}>
+          <h1 style={{ color: '#f87171', fontSize: '1.5rem', marginBottom: '0.5rem' }}>Minepanel could not load this page</h1>
+          <p style={{ fontSize: '0.875rem', color: '#9ca3af', marginBottom: '1.5rem' }}>
+            Reloading usually fixes it. If it keeps happening, disable your browser&apos;s automatic page translation and report it at
+            github.com/Ketbome/minepanel/issues.
+          </p>
+          <button
+            type="button"
+            onClick={reset}
+            style={{
+              background: '#059669',
+              color: 'white',
+              border: 'none',
+              borderRadius: '6px',
+              padding: '0.5rem 1rem',
+              cursor: 'pointer',
+            }}
+          >
+            Reload
+          </button>
+        </div>
+      </body>
+    </html>
+  );
+}

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -38,8 +38,11 @@ export const metadata: Metadata = {
 
 export default function RootLayout({ children }: { readonly children: React.ReactNode }) {
   return (
-    <html lang="en" className={`${archivo.variable} ${archivoBlack.variable} ${jetbrainsMono.variable}`}>
+    <html lang="en" translate="no" suppressHydrationWarning className={`${archivo.variable} ${archivoBlack.variable} ${jetbrainsMono.variable}`}>
       <head>
+        {/* The panel ships its own translations; browser translation rewrites
+            React-owned text nodes and breaks hydration. */}
+        <meta name="google" content="notranslate" />
         <PublicEnvScript />
       </head>
       <body>

--- a/frontend/src/components/PublicEnvScript.tsx
+++ b/frontend/src/components/PublicEnvScript.tsx
@@ -1,4 +1,4 @@
 export function PublicEnvScript() {
   // eslint-disable-next-line @next/next/no-sync-scripts
-  return <script src="/api/public-env" />;
+  return <script src={`${process.env.NEXT_PUBLIC_BASE_PATH ?? ''}/api/public-env`} />;
 }

--- a/frontend/src/components/organisms/ServerConfigTabs.tsx
+++ b/frontend/src/components/organisms/ServerConfigTabs.tsx
@@ -105,13 +105,11 @@ export const ServerConfigTabs: FC<ServerConfigTabsProps> = ({ serverId, config, 
 
   const paletteItems: TabSearchItem[] = [...tabItems, ...settingItems];
 
-  const getInitialTab = () => {
-    if (typeof window === "undefined") return "type";
-    const hash = window.location.hash.slice(1);
-    return ALL_TAB_VALUES.includes(hash) ? hash : "type";
-  };
-
-  const [activeTab, setActiveTab] = useState(getInitialTab());
+  // The tab from the URL hash is applied after mount, not during render: the
+  // server always renders "type", so reading window here would hydrate a
+  // different subtree and crash React.
+  const [activeTab, setActiveTab] = useState("type");
+  const [hashApplied, setHashApplied] = useState(false);
   const [savedConfig, setSavedConfig] = useState<ServerConfig | null>(null);
   const [hasUnsavedChanges, setHasUnsavedChanges] = useState(false);
 
@@ -133,10 +131,17 @@ export const ServerConfigTabs: FC<ServerConfigTabsProps> = ({ serverId, config, 
   }, [config, savedConfig]);
 
   useEffect(() => {
-    if (typeof window !== "undefined") {
-      window.location.hash = activeTab;
+    const hash = window.location.hash.slice(1);
+    if (ALL_TAB_VALUES.includes(hash)) {
+      setActiveTab(hash);
     }
-  }, [activeTab]);
+    setHashApplied(true);
+  }, []);
+
+  useEffect(() => {
+    if (!hashApplied) return;
+    window.location.hash = activeTab;
+  }, [activeTab, hashApplied]);
 
   useEffect(() => {
     const handleHashChange = () => {

--- a/frontend/src/lib/hooks/useLanguage.tsx
+++ b/frontend/src/lib/hooks/useLanguage.tsx
@@ -20,6 +20,10 @@ interface LanguageContextType {
 
 const LanguageContext = createContext<LanguageContextType | undefined>(undefined);
 
+// Own-property check: `'constructor' in translations` is true and would let a
+// hand-edited localStorage value through as a locale.
+const isKnownLanguage = (value: string) => Object.prototype.hasOwnProperty.call(translations, value);
+
 export function LanguageProvider({ children }: { children: ReactNode }) {
   // Always render "en" first: pages are prerendered at build time in English,
   // while NEXT_PUBLIC_DEFAULT_LANGUAGE is only known at runtime. Resolving it
@@ -28,7 +32,7 @@ export function LanguageProvider({ children }: { children: ReactNode }) {
 
   useEffect(() => {
     const savedLanguage = localStorage.getItem('language') as Language;
-    if (savedLanguage && translations[savedLanguage]) {
+    if (savedLanguage && isKnownLanguage(savedLanguage)) {
       setLanguageState(savedLanguage);
       return;
     }
@@ -36,7 +40,7 @@ export function LanguageProvider({ children }: { children: ReactNode }) {
     const envLang = getPublicEnv('NEXT_PUBLIC_DEFAULT_LANGUAGE');
     if (!envLang) return;
 
-    if (!(envLang in translations)) {
+    if (!isKnownLanguage(envLang)) {
       console.warn(
         `[Minepanel] Language "${envLang}" is not available. Available: ${Object.keys(translations).join(', ')}. Falling back to "en".`,
       );

--- a/frontend/src/lib/hooks/useLanguage.tsx
+++ b/frontend/src/lib/hooks/useLanguage.tsx
@@ -21,25 +21,34 @@ interface LanguageContextType {
 const LanguageContext = createContext<LanguageContextType | undefined>(undefined);
 
 export function LanguageProvider({ children }: { children: ReactNode }) {
-  const envLang = getPublicEnv('NEXT_PUBLIC_DEFAULT_LANGUAGE');
-  const isValidLang = envLang && envLang in translations;
-
-  if (envLang && !isValidLang) {
-    console.warn(
-      `[Minepanel] Language "${envLang}" is not available. Available: ${Object.keys(translations).join(', ')}. Falling back to "en".`,
-    );
-  }
-
-  const defaultLanguage = isValidLang ? (envLang as Language) : 'en';
-  const [language, setLanguageState] = useState<Language>(defaultLanguage);
+  // Always render "en" first: pages are prerendered at build time in English,
+  // while NEXT_PUBLIC_DEFAULT_LANGUAGE is only known at runtime. Resolving it
+  // during render would break hydration on every non-English deployment.
+  const [language, setLanguageState] = useState<Language>('en');
 
   useEffect(() => {
-    // Load language from localStorage on mount
     const savedLanguage = localStorage.getItem('language') as Language;
     if (savedLanguage && translations[savedLanguage]) {
       setLanguageState(savedLanguage);
+      return;
     }
+
+    const envLang = getPublicEnv('NEXT_PUBLIC_DEFAULT_LANGUAGE');
+    if (!envLang) return;
+
+    if (!(envLang in translations)) {
+      console.warn(
+        `[Minepanel] Language "${envLang}" is not available. Available: ${Object.keys(translations).join(', ')}. Falling back to "en".`,
+      );
+      return;
+    }
+
+    setLanguageState(envLang as Language);
   }, []);
+
+  useEffect(() => {
+    document.documentElement.lang = language;
+  }, [language]);
 
   const setLanguage = useCallback((lang: Language) => {
     setLanguageState(lang);

--- a/frontend/src/lib/translations/de.ts
+++ b/frontend/src/lib/translations/de.ts
@@ -421,6 +421,8 @@ export const de: Record<TranslationKey, string> = {
   serverNotFound: 'Server nicht gefunden',
   connectionError: 'Verbindungsfehler',
   unexpectedError: 'Unerwarteter Fehler',
+  unexpectedErrorDesc: 'Das Panel konnte diese Seite nicht darstellen. Ein Neuladen behebt das meistens.',
+  reloadPage: 'Seite neu laden',
   NO_ACCESS_TOKEN: 'Kein Zugriffstoken erhalten',
   LOGIN_ERROR: 'Anmeldefehler',
   SERVER_START_ERROR: 'Fehler beim Starten des Servers',

--- a/frontend/src/lib/translations/en.ts
+++ b/frontend/src/lib/translations/en.ts
@@ -419,6 +419,8 @@ export const en = {
   serverNotFound: 'Server not found',
   connectionError: 'Connection error',
   unexpectedError: 'Unexpected error',
+  unexpectedErrorDesc: 'The panel could not render this page. Reloading usually fixes it.',
+  reloadPage: 'Reload page',
   NO_ACCESS_TOKEN: 'No access token received',
   LOGIN_ERROR: 'Login error',
   SERVER_START_ERROR: 'Error starting server',

--- a/frontend/src/lib/translations/es.ts
+++ b/frontend/src/lib/translations/es.ts
@@ -422,6 +422,8 @@ export const es: Record<TranslationKey, string> = {
   serverNotFound: 'Servidor no encontrado',
   connectionError: 'Error de conexión',
   unexpectedError: 'Error inesperado',
+  unexpectedErrorDesc: 'El panel no pudo mostrar esta página. Recargar suele solucionarlo.',
+  reloadPage: 'Recargar página',
   NO_ACCESS_TOKEN: 'No se recibió token de acceso',
   LOGIN_ERROR: 'Error al iniciar sesión',
   SERVER_START_ERROR: 'Error al iniciar el servidor',

--- a/frontend/src/lib/translations/fr.ts
+++ b/frontend/src/lib/translations/fr.ts
@@ -421,6 +421,8 @@ export const fr: Record<TranslationKey, string> = {
   serverNotFound: 'Serveur introuvable',
   connectionError: 'Erreur de connexion',
   unexpectedError: 'Erreur inattendue',
+  unexpectedErrorDesc: "Le panneau n'a pas pu afficher cette page. Recharger règle généralement le problème.",
+  reloadPage: 'Recharger la page',
   NO_ACCESS_TOKEN: 'Aucun jeton d’accès reçu',
   LOGIN_ERROR: 'Erreur de connexion',
   SERVER_START_ERROR: 'Erreur lors du démarrage du serveur',

--- a/frontend/src/lib/translations/nl.ts
+++ b/frontend/src/lib/translations/nl.ts
@@ -425,6 +425,8 @@ export const nl: Record<TranslationKey, string> = {
   serverNotFound: 'De server is niet gevonden',
   connectionError: 'Verbindingsfout',
   unexpectedError: 'Onverwachts probleem',
+  unexpectedErrorDesc: 'Het paneel kon deze pagina niet weergeven. Opnieuw laden lost dit meestal op.',
+  reloadPage: 'Pagina opnieuw laden',
   NO_ACCESS_TOKEN: 'Er is geen toegangstoken ontvangen',
   LOGIN_ERROR: 'Inlogfout',
   SERVER_START_ERROR: 'De server kon niet worden gestart vanwege een probleem.',

--- a/frontend/src/lib/translations/pl.ts
+++ b/frontend/src/lib/translations/pl.ts
@@ -423,6 +423,8 @@ export const pl: Record<TranslationKey, string> = {
   serverNotFound: 'Nie znaleziono serwera',
   connectionError: 'Błąd połączenia',
   unexpectedError: 'Nieoczekiwany błąd',
+  unexpectedErrorDesc: 'Panel nie mógł wyświetlić tej strony. Przeładowanie zwykle to naprawia.',
+  reloadPage: 'Przeładuj stronę',
   NO_ACCESS_TOKEN: 'Nie otrzymano tokena dostępu',
   LOGIN_ERROR: 'Błąd logowania',
   SERVER_START_ERROR: 'Błąd uruchamiania serwera',

--- a/frontend/src/lib/translations/pt.ts
+++ b/frontend/src/lib/translations/pt.ts
@@ -422,6 +422,8 @@ export const pt: Record<TranslationKey, string> = {
   serverNotFound: 'Servidor não encontrado',
   connectionError: 'Erro de conexão',
   unexpectedError: 'Erro inesperado',
+  unexpectedErrorDesc: 'O painel não conseguiu exibir esta página. Recarregar costuma resolver.',
+  reloadPage: 'Recarregar página',
   NO_ACCESS_TOKEN: 'Nenhum token de acesso recebido',
   LOGIN_ERROR: 'Erro ao fazer login',
   SERVER_START_ERROR: 'Erro ao iniciar o servidor',

--- a/frontend/src/lib/translations/ru.ts
+++ b/frontend/src/lib/translations/ru.ts
@@ -421,6 +421,8 @@ export const ru: Record<TranslationKey, string> = {
   serverNotFound: 'Сервер не найден',
   connectionError: 'Ошибка подключения',
   unexpectedError: 'Непредвиденная ошибка',
+  unexpectedErrorDesc: 'Панель не смогла отобразить эту страницу. Обычно помогает перезагрузка.',
+  reloadPage: 'Перезагрузить страницу',
   NO_ACCESS_TOKEN: 'Не получен токен доступа',
   LOGIN_ERROR: 'Ошибка входа',
   SERVER_START_ERROR: 'Ошибка запуска сервера',


### PR DESCRIPTION
Closes #179.

The panel prerenders its pages at build time, always in English, but `LanguageProvider` resolved `NEXT_PUBLIC_DEFAULT_LANGUAGE` *during render* — from `process.env` on the server and from `window.__MINEPANEL_PUBLIC_ENV__` on the client. On any deployment with a language other than `en`, the prebuilt HTML says `Initializing` and the first client render says `Inicializando`, which is React #418 followed by the `insertBefore` crash while it repairs the tree. `ServerConfigTabs` had the same shape of bug for a different reason: it read `window.location.hash` during render, so reloading `/dashboard/servers/x#logs` hydrated a different subtree than the one in the HTML.

What changed:

- `useLanguage` seeds `en` and resolves localStorage / env after mount, so both sides always agree on the first render. It also keeps `document.documentElement.lang` in sync.
- `ServerConfigTabs` applies the URL hash in an effect instead of during render.
- The panel opts out of browser translation (`translate="no"` + the `notranslate` meta). Chrome's translation rewrites React-owned text nodes and produces this exact pair of errors, and the panel already ships its own 8 languages.
- `PublicEnvScript` is prefixed with `NEXT_PUBLIC_BASE_PATH`. Under a basePath deployment it was 404ing, which silently dropped both the language and the backend URL.
- Added `error.tsx` / `global-error.tsx`. There was no error boundary anywhere, so any render failure showed a blank page.

Verified with `NEXT_PUBLIC_DEFAULT_LANGUAGE=de`: React #418 on every hard load before, clean after, with the UI switching to German once mounted. Lint, typecheck and build pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added localized error pages with retry and full-page reload options.
  - Added translated unexpected-error messaging across all supported languages.
  - Added support for French and Russian as default language options.

- **Bug Fixes**
  - Improved navigation stability by preventing hydration mismatches and tab URL synchronization issues.
  - Improved deployment support for applications hosted under a custom base path.
  - Reduced conflicts with browser translation and content-injecting extensions.

- **Documentation**
  - Added troubleshooting steps for blank pages, navigation errors, and hydration issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->