### PR TITLE
feat(proxy): mc-router auto-scaling for Java servers

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -76,6 +76,19 @@ NEXT_PUBLIC_BASE_PATH=                        # Optional frontend prefix, e.g. /
 # -----------------------------------------------------------------------------
 NEXT_PUBLIC_DEFAULT_LANGUAGE=en               # Options: en, es, nl, de, pl
 
+# -----------------------------------------------------------------------------
+# Java Proxy Auto-scaling (Optional, requires the `proxy` profile)
+# -----------------------------------------------------------------------------
+# mc-router starts a server on the first connection and stops it once no player
+# has been connected for MC_PROXY_AUTOSCALE_DOWN_AFTER. It calls the panel over
+# HTTP, so the token below must be set for the feature to work at all.
+MC_PROXY_AUTOSCALE=false                       # true enables scale up + scale down
+MC_PROXY_AUTOSCALE_TOKEN=                      # Required when enabled. Generate with: openssl rand -base64 32
+MC_PROXY_AUTOSCALE_DOWN_AFTER=10m              # Idle time before stopping a server
+MC_PROXY_AUTOSCALE_WAKE_TIMEOUT=180s           # How long the router waits for a server to accept connections
+MC_PROXY_AUTOSCALE_ASLEEP_MOTD=Server is asleep. Join to wake it up!
+MC_PROXY_AUTOSCALE_LOADING_MOTD=Server is starting...
+
 # =============================================================================
 # Configuration Examples
 # =============================================================================

--- a/Readme.md
+++ b/Readme.md
@@ -53,7 +53,7 @@ If you access Minepanel over plain HTTP by local IP and login gets stuck on "Ver
 - **All server types** — Vanilla, Paper, Forge, Fabric, Purpur, and more
 - **Modpacks** — CurseForge & Modrinth integration
 - **Automatic backups** — Scheduled backups with retention policies
-- **Proxy support** — mc-router for single-port multi-server (Java)
+- **Proxy support** — mc-router for single-port multi-server (Java), with optional auto-scaling (sleep when idle, wake on join)
 - **Discord webhooks** — Server events notifications
 - **Admin + user access control** — First phase with invitations and per-user permissions
 - **Multi-language** — English, Spanish, Dutch, German, Polish

--- a/backend/AGENTS.md
+++ b/backend/AGENTS.md
@@ -104,6 +104,7 @@ Path and filesystem patterns (critical):
 - `src/files/files.controller.ts` - upload/download API behavior.
 - `src/world-discovery/world-discovery.service.ts` - `.world` library import path.
 - `src/proxy/proxy.service.ts` - proxy routes file path behavior.
+- `src/server-management/auto-scale.controller.ts` - mc-router auto-scaling webhook.
 - `package.json` - backend scripts.
 
 ## Agent-Specific Instructions
@@ -115,6 +116,7 @@ General:
 - If API contract changes, update frontend usage and docs in `doc/`.
 - Backend auth is private-by-default through a global JWT guard; only explicitly `@Public()` routes should bypass auth.
 - Keep auth transport limited to `httpOnly` cookies and bearer headers; never add JWT support via query params.
+- `POST /servers/autoscale` (`src/server-management/auto-scale.controller.ts`) is the only `@Public()` route that controls servers. It is off unless `MC_PROXY_AUTOSCALE_TOKEN` is set, authenticates mc-router with a constant-time bearer comparison, and must keep accepting only servers present in `routes.json`.
 - Optional SSO is OpenID Connect via `auth/oidc/*` (provider-agnostic; configured by `OIDC_*` env in `config.ts`). It validates the IdP `id_token` then issues the same Minepanel session cookies via `auth/utils/auth-cookies.ts`; the `client_secret` stays server-side and is never exposed. `OIDC_DISABLE_PASSWORD_LOGIN=true` blocks password login server-side (only when SSO is fully configured).
 
 Server ID and directory safety:

--- a/backend/src/config.ts
+++ b/backend/src/config.ts
@@ -60,6 +60,8 @@ export default () => ({
     pass: process.env.SMTP_PASS,
     from: process.env.SMTP_FROM,
   },
+  // Shared secret mc-router sends on auto-scale webhook calls. Unset = feature off.
+  autoScaleToken: process.env.MC_PROXY_AUTOSCALE_TOKEN || undefined,
   serversDir: '/app/servers',
   baseDir: detectHostBaseDir() || process.env.BASE_DIR || '/app',
   backupBaseDir: process.env.BACKUP_BASE_DIR || undefined,

--- a/backend/src/server-management/auto-scale.controller.spec.ts
+++ b/backend/src/server-management/auto-scale.controller.spec.ts
@@ -1,0 +1,71 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ConfigService } from '@nestjs/config';
+import { NotFoundException, UnauthorizedException } from '@nestjs/common';
+import { AutoScaleController } from './auto-scale.controller';
+import { ServerManagementService } from './server-management.service';
+import { ProxyService } from '../proxy/proxy.service';
+
+const TOKEN = 'super-secret-token';
+const AUTH = `Bearer ${TOKEN}`;
+
+describe('AutoScaleController', () => {
+  let controller: AutoScaleController;
+  let serverService: jest.Mocked<ServerManagementService>;
+  let proxyService: jest.Mocked<ProxyService>;
+  let token: string | undefined;
+
+  beforeEach(async () => {
+    token = TOKEN;
+
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [AutoScaleController],
+      providers: [
+        { provide: ConfigService, useValue: { get: jest.fn(() => token) } },
+        {
+          provide: ServerManagementService,
+          useValue: { getServerStatus: jest.fn(), startServer: jest.fn(), stopServer: jest.fn() },
+        },
+        { provide: ProxyService, useValue: { getAllMappings: jest.fn() } },
+      ],
+    }).compile();
+
+    controller = module.get(AutoScaleController);
+    serverService = module.get(ServerManagementService);
+    proxyService = module.get(ProxyService);
+
+    proxyService.getAllMappings.mockResolvedValue([{ host: 'survival.mc.example.com', backend: 'survival:25565' }]);
+  });
+
+  it('rejects a wrong token', async () => {
+    await expect(controller.autoScale('Bearer nope', { action: 'up', backend: 'survival:25565' })).rejects.toThrow(UnauthorizedException);
+  });
+
+  it('is disabled when no token is configured', async () => {
+    token = undefined;
+    await expect(controller.autoScale(AUTH, { action: 'up', backend: 'survival:25565' })).rejects.toThrow(NotFoundException);
+  });
+
+  it('rejects a backend that is not in routes.json', async () => {
+    await expect(controller.autoScale(AUTH, { action: 'up', backend: 'unknown:25565' })).rejects.toThrow(NotFoundException);
+  });
+
+  it('does not restart a server that is already running', async () => {
+    serverService.getServerStatus.mockResolvedValue('running');
+
+    await expect(controller.autoScale(AUTH, { action: 'up', backend: 'survival:25565' })).resolves.toEqual({
+      serverId: 'survival',
+      status: 'running',
+    });
+    expect(serverService.startServer).not.toHaveBeenCalled();
+  });
+
+  it('stops the server on scale down', async () => {
+    serverService.stopServer.mockResolvedValue(true);
+
+    await expect(controller.autoScale(AUTH, { action: 'down', serverAddress: 'survival.mc.example.com' })).resolves.toEqual({
+      serverId: 'survival',
+      status: 'stopped',
+    });
+    expect(serverService.stopServer).toHaveBeenCalledWith('survival');
+  });
+});

--- a/backend/src/server-management/auto-scale.controller.ts
+++ b/backend/src/server-management/auto-scale.controller.ts
@@ -1,0 +1,113 @@
+import { Body, Controller, Headers, HttpCode, Logger, NotFoundException, Post, ServiceUnavailableException, UnauthorizedException } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { timingSafeEqual } from 'node:crypto';
+import { connect } from 'node:net';
+import { Public } from 'src/auth/decorators/public.decorator';
+import { ProxyService } from 'src/proxy/proxy.service';
+import { ServerManagementService } from './server-management.service';
+import { AutoScaleDto } from './dto/auto-scale.dto';
+
+const WAKE_TIMEOUT_MS = 150_000;
+const WAKE_POLL_INTERVAL_MS = 2_000;
+
+// mc-router auto-scaling for static routes: the router asks the panel to wake a
+// server on the first connection and to put it back to sleep once idle.
+@Controller('servers')
+export class AutoScaleController {
+  private readonly logger = new Logger(AutoScaleController.name);
+
+  constructor(
+    private readonly configService: ConfigService,
+    private readonly managementService: ServerManagementService,
+    private readonly proxyService: ProxyService,
+  ) {}
+
+  @Public()
+  @Post('autoscale')
+  @HttpCode(200)
+  async autoScale(@Headers('authorization') authorization: string, @Body() body: AutoScaleDto) {
+    this.assertAuthorized(authorization);
+
+    const { serverId, port } = await this.resolveBackend(body);
+
+    if (body.action === 'down') {
+      this.logger.log(`Auto-scale down: stopping ${serverId}`);
+      if (!(await this.managementService.stopServer(serverId))) {
+        throw new ServiceUnavailableException(`Failed to stop server ${serverId}`);
+      }
+      return { serverId, status: 'stopped' };
+    }
+
+    if ((await this.managementService.getServerStatus(serverId)) === 'running') {
+      return { serverId, status: 'running' };
+    }
+
+    this.logger.log(`Auto-scale up: starting ${serverId} for ${body.serverAddress || 'default route'}`);
+    if (!(await this.managementService.startServer(serverId))) {
+      throw new ServiceUnavailableException(`Failed to start server ${serverId}`);
+    }
+
+    if (!(await this.waitForPort(serverId, port))) {
+      throw new ServiceUnavailableException(`Server ${serverId} is still starting`);
+    }
+
+    return { serverId, status: 'running' };
+  }
+
+  private assertAuthorized(authorization?: string): void {
+    const token = this.configService.get<string>('autoScaleToken');
+    if (!token) {
+      throw new NotFoundException();
+    }
+
+    const provided = authorization?.startsWith('Bearer ') ? authorization.slice(7) : '';
+    const expected = Buffer.from(token);
+    const received = Buffer.from(provided);
+
+    if (received.length !== expected.length || !timingSafeEqual(received, expected)) {
+      throw new UnauthorizedException();
+    }
+  }
+
+  // Only servers currently present in routes.json can be scaled, so a leaked
+  // token cannot drive arbitrary servers.
+  private async resolveBackend(body: AutoScaleDto): Promise<{ serverId: string; port: number }> {
+    const mappings = await this.proxyService.getAllMappings();
+    const mapping = body.backend
+      ? mappings.find((m) => m.backend === body.backend)
+      : mappings.find((m) => m.host === body.serverAddress);
+
+    if (!mapping) {
+      throw new NotFoundException(`No proxy route matches ${body.backend || body.serverAddress}`);
+    }
+
+    const [serverId, port] = mapping.backend.split(':');
+    return { serverId, port: Number(port) || 25565 };
+  }
+
+  private async waitForPort(serverId: string, port: number): Promise<boolean> {
+    const deadline = Date.now() + WAKE_TIMEOUT_MS;
+
+    while (Date.now() < deadline) {
+      if (await this.isPortOpen(serverId, port)) {
+        return true;
+      }
+      await new Promise((resolve) => setTimeout(resolve, WAKE_POLL_INTERVAL_MS));
+    }
+
+    return false;
+  }
+
+  private isPortOpen(host: string, port: number): Promise<boolean> {
+    return new Promise((resolve) => {
+      const socket = connect({ host, port, timeout: WAKE_POLL_INTERVAL_MS });
+      const finish = (open: boolean) => {
+        socket.destroy();
+        resolve(open);
+      };
+      socket.once('connect', () => finish(true));
+      socket.once('timeout', () => finish(false));
+      socket.once('error', () => finish(false));
+    });
+  }
+}

--- a/backend/src/server-management/dto/auto-scale.dto.ts
+++ b/backend/src/server-management/dto/auto-scale.dto.ts
@@ -1,0 +1,15 @@
+import { IsIn, IsOptional, IsString } from 'class-validator';
+
+// Payload sent by mc-router when auto-scaling a statically-routed server.
+export class AutoScaleDto {
+  @IsIn(['up', 'down'])
+  action: 'up' | 'down';
+
+  @IsString()
+  @IsOptional()
+  serverAddress?: string;
+
+  @IsString()
+  @IsOptional()
+  backend?: string;
+}

--- a/backend/src/server-management/server-management.module.ts
+++ b/backend/src/server-management/server-management.module.ts
@@ -1,6 +1,7 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { ServerManagementController } from './server-management.controller';
+import { AutoScaleController } from './auto-scale.controller';
 import { ServerManagementService } from './server-management.service';
 import { DockerComposeService } from 'src/docker-compose/docker-compose.service';
 import { DiscordModule } from 'src/discord/discord.module';
@@ -12,7 +13,7 @@ import { AlertsModule } from 'src/alerts/alerts.module';
 
 @Module({
   imports: [TypeOrmModule.forFeature([Settings]), DiscordModule, UsersModule, ProxyModule, BedrockAddonsModule, AlertsModule],
-  controllers: [ServerManagementController],
+  controllers: [ServerManagementController, AutoScaleController],
   providers: [ServerManagementService, DockerComposeService],
   exports: [ServerManagementService, DockerComposeService],
 })

--- a/doc/api.md
+++ b/doc/api.md
@@ -47,6 +47,7 @@ These routes do not require an authenticated session:
 | `POST` | `/auth/logout` | Clear session cookies and revoke refresh token when present |
 | `GET` | `/auth/oidc/login` | Begin SSO login, redirects to the OIDC provider (when SSO is configured) |
 | `GET` | `/auth/oidc/callback` | OIDC provider callback; sets session cookies and redirects to the dashboard |
+| `POST` | `/servers/autoscale` | mc-router auto-scaling webhook; disabled unless `MC_PROXY_AUTOSCALE_TOKEN` is set |
 
 All other endpoints require JWT authentication. See [Single Sign-On](/sso) for SSO setup.
 
@@ -203,6 +204,16 @@ mc-router proxy status and mapping management:
 - `GET /proxy/server/:id/hostname`
 - `POST /proxy/server/:id`
 - `DELETE /proxy/server/:id`
+
+Auto-scaling webhook, called by mc-router (see [Networking](/networking#auto-scaling-sleep-when-idle)):
+
+- `POST /servers/autoscale`
+
+```json
+{ "action": "up", "serverAddress": "survival.mc.example.com", "backend": "survival:25565" }
+```
+
+Requires `Authorization: Bearer <MC_PROXY_AUTOSCALE_TOKEN>`. `action: "up"` starts the server and only answers `200` once it accepts connections; `action: "down"` stops it. Servers that are not in the proxy routes are rejected with `404`.
 
 ## Response Patterns
 

--- a/doc/networking.md
+++ b/doc/networking.md
@@ -197,6 +197,33 @@ docker compose --profile proxy up -d
 
 Java servers auto-get hostnames: `{server-id}.mc.example.com`
 
+### Auto-scaling (sleep when idle)
+
+mc-router can keep idle servers stopped and start them again on the first connection. The router does not talk to Docker: it calls the panel, which starts and stops the server the same way the UI does.
+
+1. **Generate a token** and enable the feature in `.env`:
+
+```bash
+# .env
+MC_PROXY_AUTOSCALE=true
+MC_PROXY_AUTOSCALE_TOKEN=<openssl rand -base64 32>
+MC_PROXY_AUTOSCALE_DOWN_AFTER=10m
+```
+
+2. **Recreate both services** so they pick up the token:
+
+```bash
+docker compose --profile proxy up -d
+```
+
+While a server is asleep, its MOTD shows `Server is asleep. Join to wake it up!`. Joining triggers the wake-up; the router waits up to `MC_PROXY_AUTOSCALE_WAKE_TIMEOUT` (180s by default) for the server to accept connections, so the first join on a heavy modpack may time out. Reconnect and it will be ready.
+
+::: warning This stops running servers
+With `MC_PROXY_AUTOSCALE=true`, any proxied Java server with no players for `MC_PROXY_AUTOSCALE_DOWN_AFTER` is stopped, including ones you started manually. Only servers listed in the proxy routes are affected; Bedrock servers are never touched.
+:::
+
+The panel exposes `POST /servers/autoscale` for this. It is the only unauthenticated endpoint that controls servers, it is rejected unless `MC_PROXY_AUTOSCALE_TOKEN` is set and sent as `Authorization: Bearer <token>`, and it only accepts servers that are currently in the proxy routes.
+
 ### Bedrock Connection
 
 Bedrock servers connect directly via IP and port:

--- a/docker-compose.development.yml
+++ b/docker-compose.development.yml
@@ -18,6 +18,7 @@ services:
       - BASE_DIR=${BASE_DIR:-$PWD}
       - COMPOSE_PROJECT=${COMPOSE_PROJECT:-}
       - BASE_PATH=${BASE_PATH:-}
+      - MC_PROXY_AUTOSCALE_TOKEN=${MC_PROXY_AUTOSCALE_TOKEN:-}
     volumes:
       - ${BASE_DIR:-$PWD}/servers:/app/servers
       - /var/run/docker.sock:/var/run/docker.sock
@@ -49,7 +50,7 @@ services:
   # Enable with: docker compose -f docker-compose.development.yml --profile proxy up -d --build
   # Requires DNS wildcard: *.mc.yourdomain.com -> server IP
   mc-router:
-    image: itzg/mc-router:1.39.1
+    image: itzg/mc-router:1.46.2
     container_name: mc-router
     profiles:
       - proxy
@@ -58,6 +59,16 @@ services:
     environment:
       - ROUTES_CONFIG=/data/routes.json
       - ROUTES_CONFIG_WATCH=true
+      # Auto-scaling (optional): the router asks the panel to start a server on
+      # the first connection and to stop it once idle. Needs MC_PROXY_AUTOSCALE_TOKEN.
+      - AUTO_SCALE_UP=${MC_PROXY_AUTOSCALE:-false}
+      - AUTO_SCALE_DOWN=${MC_PROXY_AUTOSCALE:-false}
+      - AUTO_SCALE_DOWN_AFTER=${MC_PROXY_AUTOSCALE_DOWN_AFTER:-10m}
+      - AUTO_SCALE_WEBHOOK_URL=http://backend:8091${BASE_PATH:-}/servers/autoscale
+      - AUTO_SCALE_WEBHOOK_HEADERS=Authorization=Bearer ${MC_PROXY_AUTOSCALE_TOKEN:-}
+      - AUTO_SCALE_WEBHOOK_WAKE_TIMEOUT=${MC_PROXY_AUTOSCALE_WAKE_TIMEOUT:-180s}
+      - AUTO_SCALE_ASLEEP_MOTD=${MC_PROXY_AUTOSCALE_ASLEEP_MOTD:-Server is asleep. Join to wake it up!}
+      - AUTO_SCALE_LOADING_MOTD=${MC_PROXY_AUTOSCALE_LOADING_MOTD:-Server is starting...}
     volumes:
       - ${BASE_DIR:-$PWD}/data/proxy:/data
     networks:

--- a/docker-compose.single.yml
+++ b/docker-compose.single.yml
@@ -25,6 +25,7 @@ services:
       # Subdirectory Routing (optional). `NEXT_PUBLIC_BASE_PATH` only changes the frontend if the image was built with the same value.
       - BASE_PATH=${BASE_PATH:-}
       - NEXT_PUBLIC_BASE_PATH=${NEXT_PUBLIC_BASE_PATH:-}
+      - MC_PROXY_AUTOSCALE_TOKEN=${MC_PROXY_AUTOSCALE_TOKEN:-}
     volumes:
       - ${BASE_DIR:-$PWD}/servers:/app/servers
       - /var/run/docker.sock:/var/run/docker.sock
@@ -37,7 +38,7 @@ services:
   # Enable with: docker compose --profile proxy up -d
   # Requires DNS wildcard: *.mc.yourdomain.com -> server IP
   mc-router:
-    image: itzg/mc-router:1.39.1
+    image: itzg/mc-router:1.46.2
     container_name: mc-router
     profiles:
       - proxy
@@ -46,6 +47,16 @@ services:
     environment:
       - ROUTES_CONFIG=/data/routes.json
       - ROUTES_CONFIG_WATCH=true
+      # Auto-scaling (optional): the router asks the panel to start a server on
+      # the first connection and to stop it once idle. Needs MC_PROXY_AUTOSCALE_TOKEN.
+      - AUTO_SCALE_UP=${MC_PROXY_AUTOSCALE:-false}
+      - AUTO_SCALE_DOWN=${MC_PROXY_AUTOSCALE:-false}
+      - AUTO_SCALE_DOWN_AFTER=${MC_PROXY_AUTOSCALE_DOWN_AFTER:-10m}
+      - AUTO_SCALE_WEBHOOK_URL=http://minepanel:8091${BASE_PATH:-}/servers/autoscale
+      - AUTO_SCALE_WEBHOOK_HEADERS=Authorization=Bearer ${MC_PROXY_AUTOSCALE_TOKEN:-}
+      - AUTO_SCALE_WEBHOOK_WAKE_TIMEOUT=${MC_PROXY_AUTOSCALE_WAKE_TIMEOUT:-180s}
+      - AUTO_SCALE_ASLEEP_MOTD=${MC_PROXY_AUTOSCALE_ASLEEP_MOTD:-Server is asleep. Join to wake it up!}
+      - AUTO_SCALE_LOADING_MOTD=${MC_PROXY_AUTOSCALE_LOADING_MOTD:-Server is starting...}
     volumes:
       - ${BASE_DIR:-$PWD}/data/proxy:/data
     networks:

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -27,6 +27,7 @@ services:
       - BASE_DIR=${BASE_DIR:-$PWD}
       - COMPOSE_PROJECT=${COMPOSE_PROJECT:-}
       - BASE_PATH=${BASE_PATH:-}
+      - MC_PROXY_AUTOSCALE_TOKEN=${MC_PROXY_AUTOSCALE_TOKEN:-}
     volumes:
       - ${BASE_DIR:-$PWD}/servers:/app/servers
       - /var/run/docker.sock:/var/run/docker.sock
@@ -53,7 +54,7 @@ services:
   # Note: mc-router only works with Java Edition (TCP). Bedrock uses UDP and doesn't support proxy routing.
   # Enable with: docker compose -f docker-compose.test.yml --profile proxy up -d
   mc-router:
-    image: itzg/mc-router:1.39.1
+    image: itzg/mc-router:1.46.2
     container_name: mc-router
     profiles:
       - proxy
@@ -62,6 +63,16 @@ services:
     environment:
       - ROUTES_CONFIG=/data/routes.json
       - ROUTES_CONFIG_WATCH=true
+      # Auto-scaling (optional): the router asks the panel to start a server on
+      # the first connection and to stop it once idle. Needs MC_PROXY_AUTOSCALE_TOKEN.
+      - AUTO_SCALE_UP=${MC_PROXY_AUTOSCALE:-false}
+      - AUTO_SCALE_DOWN=${MC_PROXY_AUTOSCALE:-false}
+      - AUTO_SCALE_DOWN_AFTER=${MC_PROXY_AUTOSCALE_DOWN_AFTER:-10m}
+      - AUTO_SCALE_WEBHOOK_URL=http://backend:8091${BASE_PATH:-}/servers/autoscale
+      - AUTO_SCALE_WEBHOOK_HEADERS=Authorization=Bearer ${MC_PROXY_AUTOSCALE_TOKEN:-}
+      - AUTO_SCALE_WEBHOOK_WAKE_TIMEOUT=${MC_PROXY_AUTOSCALE_WAKE_TIMEOUT:-180s}
+      - AUTO_SCALE_ASLEEP_MOTD=${MC_PROXY_AUTOSCALE_ASLEEP_MOTD:-Server is asleep. Join to wake it up!}
+      - AUTO_SCALE_LOADING_MOTD=${MC_PROXY_AUTOSCALE_LOADING_MOTD:-Server is starting...}
     volumes:
       - ${BASE_DIR:-$PWD}/data/proxy:/data
     networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,6 +17,7 @@ services:
       - BASE_DIR=${BASE_DIR:-$PWD}
       - COMPOSE_PROJECT=${COMPOSE_PROJECT:-}
       - BASE_PATH=${BASE_PATH:-}
+      - MC_PROXY_AUTOSCALE_TOKEN=${MC_PROXY_AUTOSCALE_TOKEN:-}
     volumes:
       - ${BASE_DIR:-$PWD}/servers:/app/servers
       - /var/run/docker.sock:/var/run/docker.sock
@@ -41,7 +42,7 @@ services:
   # Enable with: docker compose --profile proxy up -d
   # Requires DNS wildcard: *.mc.yourdomain.com -> server IP
   mc-router:
-    image: itzg/mc-router:1.39.1
+    image: itzg/mc-router:1.46.2
     container_name: mc-router
     profiles:
       - proxy
@@ -50,6 +51,16 @@ services:
     environment:
       - ROUTES_CONFIG=/data/routes.json
       - ROUTES_CONFIG_WATCH=true
+      # Auto-scaling (optional): the router asks the panel to start a server on
+      # the first connection and to stop it once idle. Needs MC_PROXY_AUTOSCALE_TOKEN.
+      - AUTO_SCALE_UP=${MC_PROXY_AUTOSCALE:-false}
+      - AUTO_SCALE_DOWN=${MC_PROXY_AUTOSCALE:-false}
+      - AUTO_SCALE_DOWN_AFTER=${MC_PROXY_AUTOSCALE_DOWN_AFTER:-10m}
+      - AUTO_SCALE_WEBHOOK_URL=http://backend:8091${BASE_PATH:-}/servers/autoscale
+      - AUTO_SCALE_WEBHOOK_HEADERS=Authorization=Bearer ${MC_PROXY_AUTOSCALE_TOKEN:-}
+      - AUTO_SCALE_WEBHOOK_WAKE_TIMEOUT=${MC_PROXY_AUTOSCALE_WAKE_TIMEOUT:-180s}
+      - AUTO_SCALE_ASLEEP_MOTD=${MC_PROXY_AUTOSCALE_ASLEEP_MOTD:-Server is asleep. Join to wake it up!}
+      - AUTO_SCALE_LOADING_MOTD=${MC_PROXY_AUTOSCALE_LOADING_MOTD:-Server is starting...}
     volumes:
       - ${BASE_DIR:-$PWD}/data/proxy:/data
     networks:


### PR DESCRIPTION
Closes #175.

The issue suggested Docker label discovery (`IN_DOCKER` + `mc-router.host`), but that can't work here: Minepanel routes through a static `routes.json`, and mc-router only auto-scales routes it discovered itself. For static routes there's a webhook, added upstream in 1.43.0 — the router POSTs `{"action":"up"|"down", serverAddress, backend}` and whoever receives it decides what to do. That fits the panel much better: mc-router never needs the Docker socket, routes aren't discovered twice, and the panel stays the only thing that starts and stops servers.

What changed:

- `itzg/mc-router` 1.39.1 → 1.46.2 across the four compose files, plus an opt-in `AUTO_SCALE_*` block driven by `MC_PROXY_AUTOSCALE*` variables.
- New `POST /servers/autoscale`. It's `@Public()` because mc-router can't hold a session, so instead: it 404s unless `MC_PROXY_AUTOSCALE_TOKEN` is set, authenticates the bearer token with a constant-time comparison, and only accepts servers that are currently in `routes.json`.
- `up` short-circuits when the server is already running — `startServer` does a `compose down` first, so calling it blindly would restart a live server. Otherwise it starts the server and waits for the port to accept connections before answering, so mc-router doesn't hand the player a backend that isn't listening yet.
- Documented in `networking.md`, `api.md` and `.env.example`, including the warning that scale-down will stop servers an admin started by hand.

Tests cover the token rejection, the disabled-by-default path, unknown backends and the already-running short circuit.

Not in scope: per-server auto-scale toggles in the UI. This first pass is configured by env like the rest of the `proxy` profile.
