### PR TITLE
feat(frontend): lighten server rows, rebuild header, add a styled 404

### DIFF
--- a/frontend/src/app/dashboard/servers/page.tsx
+++ b/frontend/src/app/dashboard/servers/page.tsx
@@ -8,7 +8,7 @@ import {
   Plus,
   Loader2,
   Trash2,
-  Settings as SettingsIcon,
+  ChevronRight,
   Zap,
   LayoutTemplate,
   Check,
@@ -319,7 +319,7 @@ export default function Dashboard() {
           >
             {canCreateServers ? (
               <DialogTrigger asChild>
-                <button className="mc-btn mc-btn-emerald px-4 py-2.5 self-start">
+                <button className="mc-btn mc-btn-emerald px-4 py-2 text-sm self-start">
                   <Plus className="h-4 w-4" />
                   {t('createServer')}
                 </button>
@@ -564,135 +564,138 @@ export default function Dashboard() {
             </button>
           </div>
         ) : (
-          <div className="flex flex-col gap-4">
+          <div className="flex flex-col gap-2.5">
             {servers.map((server: ServerInfo, index: number) => (
               <div
                 key={server.id}
                 className={`animate-fade-in-up stagger-${Math.min(index + 1, 6)}`}
               >
-                <div className="mc-panel group overflow-hidden flex items-stretch transition-transform duration-200 hover:-translate-y-0.5">
-                  <div className={`w-2 shrink-0 ${getStatusColor(server.status)}`}></div>
+                <div className="mc-panel group overflow-hidden transition-[transform,box-shadow] duration-200 hover:-translate-y-0.5 hover:shadow-[inset_3px_3px_0_rgba(255,255,255,0.1),inset_-3px_-3px_0_rgba(0,0,0,0.5),6px_6px_0_rgba(157,255,63,0.28)] focus-within:shadow-[inset_3px_3px_0_rgba(255,255,255,0.1),inset_-3px_-3px_0_rgba(0,0,0,0.5),6px_6px_0_rgba(157,255,63,0.28)]">
+                  {/* Single direct child: `.mc-panel > *` forces position/z-index,
+                      which would break the stretched link if applied to it. */}
+                  <div className="flex items-stretch">
+                    <div className={`w-1.5 shrink-0 ${getStatusColor(server.status)}`}></div>
 
-                  <div className="flex flex-1 min-w-0 flex-wrap lg:flex-nowrap items-center gap-x-5 gap-y-3 px-4 py-4 sm:px-5">
-                    <div className="flex items-center gap-3 min-w-0 flex-1 basis-56">
-                      <div className="mc-slot relative w-12 h-12 flex items-center justify-center shrink-0">
-                        <Image
-                          src={getStatusIcon(server.status)}
-                          alt="Server Status"
-                          width={34}
-                          height={34}
-                          className="pixelated object-contain"
-                        />
-                        <div
-                          className={`absolute -bottom-1 -right-1 w-3.5 h-3.5 rounded-full border-2 border-(--mc-frame) ${getStatusColor(server.status)}`}
-                        />
+                    <Link
+                      href={`/dashboard/servers/${server.id}`}
+                      aria-label={`${t('configure')} ${server.id}`}
+                      className="absolute inset-0 z-10 focus:outline-none"
+                    />
+
+                    <div className="flex flex-1 min-w-0 flex-wrap sm:flex-nowrap items-center gap-x-4 gap-y-2 px-3 py-2.5 sm:px-4">
+                      <div className="flex items-center gap-3 min-w-0 flex-1 basis-56">
+                        <div className="mc-slot relative w-10 h-10 flex items-center justify-center shrink-0">
+                          <Image
+                            src={getStatusIcon(server.status)}
+                            alt="Server Status"
+                            width={26}
+                            height={26}
+                            className="pixelated object-contain"
+                          />
+                        </div>
+                        <div className="min-w-0">
+                          <p
+                            className="text-white font-minecraft text-sm leading-tight group-hover:text-emerald-400 transition-colors truncate"
+                            title={server.id}
+                          >
+                            {server.id}
+                          </p>
+                          <p className="text-gray-400 text-xs truncate">{server.description}</p>
+                        </div>
                       </div>
-                      <div className="min-w-0">
-                        <p
-                          className="text-white font-minecraft text-base leading-tight group-hover:text-emerald-400 transition-colors truncate"
-                          title={server.id}
-                        >
-                          {server.id}
+
+                      <div className="hidden md:block shrink-0 text-right leading-tight font-mono text-xs">
+                        <p className="text-gray-300" title={t('port')}>
+                          :{server.port}
                         </p>
-                        <p className="text-gray-400 text-sm truncate">{server.description}</p>
-                      </div>
-                    </div>
-
-                    <div className="hidden md:flex items-center gap-6 shrink-0 text-sm">
-                      <div>
-                        <p className="text-gray-400 text-xs">{t('port')}</p>
-                        <p className="text-white font-medium">{server.port}</p>
-                      </div>
-                      <div className="max-w-40">
-                        <p className="text-gray-400 text-xs">{t('container')}</p>
-                        <p className="text-white font-medium truncate" title={server.containerName}>
+                        <p className="text-gray-500 truncate max-w-40" title={t('container')}>
                           {server.containerName}
                         </p>
                       </div>
-                    </div>
 
-                    <Badge
-                      variant="outline"
-                      className={`px-3 py-1 shrink-0 ${getStatusBadgeClass(server.status)}`}
-                    >
-                      {server.status === 'loading' || server.status === 'starting' ? (
-                        <span className="flex items-center gap-1.5">
-                          <Loader2 className="h-3 w-3 animate-spin" />
-                          {getStatusText(server.status)}
-                        </span>
-                      ) : (
-                        <span className="flex items-center gap-1.5">
-                          <div className="w-2 h-2 rounded-full bg-current"></div>
-                          {getStatusText(server.status)}
-                        </span>
-                      )}
-                    </Badge>
+                      <Badge
+                        variant="outline"
+                        className={`px-2 py-0.5 text-[11px] shrink-0 ${getStatusBadgeClass(server.status)}`}
+                      >
+                        {server.status === 'loading' || server.status === 'starting' ? (
+                          <span className="flex items-center gap-1.5">
+                            <Loader2 className="h-3 w-3 animate-spin" />
+                            {getStatusText(server.status)}
+                          </span>
+                        ) : (
+                          <span className="flex items-center gap-1.5">
+                            <div className="w-1.5 h-1.5 rounded-full bg-current"></div>
+                            {getStatusText(server.status)}
+                          </span>
+                        )}
+                      </Badge>
 
-                    <div className="flex gap-2 shrink-0 w-full sm:w-auto sm:ml-auto">
-                      <Link href={`/dashboard/servers/${server.id}`} className="flex-1">
-                        <button className="mc-btn mc-btn-emerald w-full py-2.5 px-2">
-                          <SettingsIcon className="h-4 w-4" />
-                          {t('configure')}
-                        </button>
-                      </Link>
-
-                      {canCreateServers && (
-                        <button
-                          className="mc-btn px-3 py-2.5"
-                          title={t('cloneServer')}
-                          onClick={() => {
-                            setCloneNewId(`${server.id}-copy`);
-                            setCloneSource(server.id);
-                          }}
-                        >
-                          <Copy className="h-4 w-4" />
-                        </button>
-                      )}
-
-                      <AlertDialog>
-                        <AlertDialogTrigger asChild>
+                      <div className="relative z-20 flex items-center gap-0.5 shrink-0 ml-auto">
+                        {canCreateServers && (
                           <button
-                            className="mc-btn px-3 py-2.5 text-red-300"
-                            style={{ background: 'linear-gradient(180deg,#b94a4a,#8f3636)' }}
+                            className="mc-iconbtn"
+                            title={t('cloneServer')}
+                            aria-label={t('cloneServer')}
+                            onClick={() => {
+                              setCloneNewId(`${server.id}-copy`);
+                              setCloneSource(server.id);
+                            }}
                           >
-                            <Trash2 className="h-4 w-4" />
+                            <Copy className="h-4 w-4" />
                           </button>
-                        </AlertDialogTrigger>
-                        <AlertDialogContent className="bg-gray-900 border-gray-700 text-white">
-                          <AlertDialogHeader>
-                            <AlertDialogTitle className="font-minecraft">
-                              {t('deleteServerTitle')}
-                            </AlertDialogTitle>
-                            <AlertDialogDescription className="text-gray-400">
-                              {t('deleteServerWarning')} &quot;{server.id}&quot;?
-                              <br />
-                              {t('cannotBeUndone')}
-                            </AlertDialogDescription>
-                          </AlertDialogHeader>
-                          <AlertDialogFooter>
-                            <AlertDialogCancel className="bg-gray-700 hover:bg-gray-600">
-                              {t('cancel')}
-                            </AlertDialogCancel>
-                            <AlertDialogAction
-                              onClick={(e) => {
-                                e.preventDefault();
-                                handleDeleteServer(server.id);
-                              }}
-                              className="bg-red-600 hover:bg-red-700 text-white"
-                              disabled={isDeletingServer === server.id}
+                        )}
+
+                        <AlertDialog>
+                          <AlertDialogTrigger asChild>
+                            <button
+                              className="mc-iconbtn mc-iconbtn--danger"
+                              title={t('delete')}
+                              aria-label={t('delete')}
                             >
-                              {isDeletingServer === server.id ? (
-                                <>
-                                  <Loader2 className="h-4 w-4 mr-2 animate-spin" />
-                                  {t('eliminating')}
-                                </>
-                              ) : (
-                                t('delete')
-                              )}
-                            </AlertDialogAction>
-                          </AlertDialogFooter>
-                        </AlertDialogContent>
-                      </AlertDialog>
+                              <Trash2 className="h-4 w-4" />
+                            </button>
+                          </AlertDialogTrigger>
+                          <AlertDialogContent className="bg-gray-900 border-gray-700 text-white">
+                            <AlertDialogHeader>
+                              <AlertDialogTitle className="font-minecraft">
+                                {t('deleteServerTitle')}
+                              </AlertDialogTitle>
+                              <AlertDialogDescription className="text-gray-400">
+                                {t('deleteServerWarning')} &quot;{server.id}&quot;?
+                                <br />
+                                {t('cannotBeUndone')}
+                              </AlertDialogDescription>
+                            </AlertDialogHeader>
+                            <AlertDialogFooter>
+                              <AlertDialogCancel className="bg-gray-700 hover:bg-gray-600">
+                                {t('cancel')}
+                              </AlertDialogCancel>
+                              <AlertDialogAction
+                                onClick={(e) => {
+                                  e.preventDefault();
+                                  handleDeleteServer(server.id);
+                                }}
+                                className="bg-red-600 hover:bg-red-700 text-white"
+                                disabled={isDeletingServer === server.id}
+                              >
+                                {isDeletingServer === server.id ? (
+                                  <>
+                                    <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+                                    {t('eliminating')}
+                                  </>
+                                ) : (
+                                  t('delete')
+                                )}
+                              </AlertDialogAction>
+                            </AlertDialogFooter>
+                          </AlertDialogContent>
+                        </AlertDialog>
+                      </div>
+
+                      <ChevronRight
+                        className="hidden sm:block h-4 w-4 shrink-0 text-gray-600 transition-all duration-200 group-hover:translate-x-0.5 group-hover:text-emerald-400"
+                        aria-hidden="true"
+                      />
                     </div>
                   </div>
                 </div>

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -688,6 +688,38 @@
   background: linear-gradient(180deg, #8a63d6, #5f3fa3);
 }
 
+/* Quiet square icon action for secondary row controls; only reveals its
+   slot bevel on hover so lists don't fill up with competing buttons. */
+.mc-iconbtn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  color: rgba(234, 255, 242, 0.5);
+  background: transparent;
+  border: 2px solid transparent;
+  border-radius: 0;
+  cursor: pointer;
+  transition: color 0.12s ease, background 0.12s ease, border-color 0.12s ease;
+}
+
+.mc-iconbtn:hover {
+  color: var(--mc-emerald);
+  background: var(--mc-stone-deep);
+  border-color: var(--mc-frame);
+  box-shadow: inset 2px 2px 0 rgba(0, 0, 0, 0.55), inset -2px -2px 0 rgba(255, 255, 255, 0.06);
+}
+
+.mc-iconbtn:focus-visible {
+  outline: 2px solid var(--mc-emerald);
+  outline-offset: -2px;
+}
+
+.mc-iconbtn--danger:hover {
+  color: var(--mc-redstone);
+}
+
 /* Segmented XP / resource bar */
 .mc-bar {
   position: relative;

--- a/frontend/src/app/not-found.tsx
+++ b/frontend/src/app/not-found.tsx
@@ -1,0 +1,46 @@
+'use client';
+
+import Image from 'next/image';
+import Link from 'next/link';
+import { Home, LayoutDashboard } from 'lucide-react';
+import { useLanguage } from '@/lib/hooks/useLanguage';
+
+export default function NotFound() {
+  const { t } = useLanguage();
+
+  return (
+    <div className="flex min-h-screen mp-blueprint items-center justify-center p-6">
+      <div className="mc-panel w-full max-w-lg animate-fade-in-up">
+        <div className="mc-titlebar flex items-center gap-3 px-4 py-3">
+          <Image
+            src="/images/barrier.webp"
+            alt=""
+            width={24}
+            height={24}
+            className="pixelated animate-float"
+          />
+          <span className="mp-tag">Error 404</span>
+        </div>
+
+        <div className="px-6 py-10 text-center">
+          <p className="font-minecraft text-6xl leading-none text-[var(--mc-emerald)] drop-shadow-glow">
+            404
+          </p>
+          <h1 className="mt-4 font-minecraft text-xl text-white">{t('pageNotFoundTitle')}</h1>
+          <p className="mt-2 text-sm text-gray-400">{t('pageNotFoundDesc')}</p>
+
+          <div className="mt-8 flex flex-col justify-center gap-2 sm:flex-row">
+            <Link href="/dashboard/home" className="mc-btn mc-btn-emerald px-4 py-2 text-sm">
+              <Home className="h-4 w-4" />
+              {t('home')}
+            </Link>
+            <Link href="/dashboard/servers" className="mc-btn px-4 py-2 text-sm">
+              <LayoutDashboard className="h-4 w-4" />
+              {t('dashboard')}
+            </Link>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/organisms/DashboardHeader.tsx
+++ b/frontend/src/components/organisms/DashboardHeader.tsx
@@ -1,18 +1,25 @@
-"use client";
+'use client';
 
-import { useState, useEffect, useRef } from "react";
-import Image from "next/image";
-import { LogOut, ChevronDown } from "lucide-react";
-import { LanguageSwitcher } from "../ui/language-switcher";
-import { useLanguage } from "@/lib/hooks/useLanguage";
-import { useAuthStore } from "@/lib/store/auth-store";
-import { cn } from "@/lib/utils";
-import { getSessionUser, type SessionUser } from "@/services/auth/auth.service";
-import { GitHubStarButton } from "@/components/molecules/GitHubStarButton";
+import { useState, useEffect, useRef } from 'react';
+import Image from 'next/image';
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+import { LogOut, ChevronDown } from 'lucide-react';
+import { LanguageSwitcher } from '../ui/language-switcher';
+import { useLanguage } from '@/lib/hooks/useLanguage';
+import { useAuthStore } from '@/lib/store/auth-store';
+import { useServerNavStore } from '@/lib/store';
+import { cn } from '@/lib/utils';
+import { getSessionUser, type SessionUser } from '@/services/auth/auth.service';
+import { GitHubStarButton } from '@/components/molecules/GitHubStarButton';
+
+type Crumb = { label: string; href?: string };
 
 export function DashboardHeader() {
   const { t } = useLanguage();
+  const pathname = usePathname();
   const logout = useAuthStore((state) => state.logout);
+  const storeServerName = useServerNavStore((state) => state.serverName);
   const [showUserMenu, setShowUserMenu] = useState(false);
   const [sessionUser, setSessionUser] = useState<SessionUser | null>(null);
   const menuRef = useRef<HTMLDivElement>(null);
@@ -24,15 +31,15 @@ export function DashboardHeader() {
       }
     };
 
-    document.addEventListener("mousedown", handleClickOutside);
-    return () => document.removeEventListener("mousedown", handleClickOutside);
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => document.removeEventListener('mousedown', handleClickOutside);
   }, []);
 
   useEffect(() => {
     getSessionUser()
       .then(setSessionUser)
       .catch((error) => {
-        console.error("Error loading session user:", error);
+        console.error('Error loading session user:', error);
         setSessionUser(null);
       });
   }, []);
@@ -41,68 +48,154 @@ export function DashboardHeader() {
     logout();
   };
 
+  const serverMatch = pathname.match(/^\/dashboard\/servers\/([^/]+)$/);
+  const crumbs: Crumb[] = (() => {
+    if (serverMatch) {
+      return [
+        { label: t('dashboard'), href: '/dashboard/servers' },
+        { label: storeServerName || decodeURIComponent(serverMatch[1]) },
+      ];
+    }
+    switch (pathname) {
+      case '/dashboard/home':
+        return [{ label: t('home') }];
+      case '/dashboard/servers':
+        return [{ label: t('dashboard') }];
+      case '/dashboard/files':
+        return [{ label: t('files') }];
+      case '/dashboard/world-library':
+        return [{ label: t('worldLibrary') }];
+      case '/dashboard/templates':
+        return [{ label: t('templates') }];
+      case '/dashboard/settings':
+        return [{ label: t('settings') }];
+      default:
+        return [{ label: t('dashboard') }];
+    }
+  })();
+
   return (
     <header className="sticky top-0 z-40 w-full mc-titlebar bg-[var(--mc-stone)]/95 backdrop-blur-md animate-fade-in">
-      <div className="flex h-16 items-center justify-end px-6 gap-3">
-        <GitHubStarButton label={t("github")} />
+      <div className="flex h-14 items-center gap-3 px-6">
+        <nav aria-label="Breadcrumb" className="mp-tag flex min-w-0 items-center gap-2 truncate">
+          {crumbs.map((crumb, index) => {
+            const isLast = index === crumbs.length - 1;
+            return (
+              <span key={crumb.label} className="flex min-w-0 items-center gap-2">
+                {index > 0 && <span className="text-gray-600">/</span>}
+                {crumb.href && !isLast ? (
+                  <Link
+                    href={crumb.href}
+                    className="text-gray-400 transition-colors hover:text-[var(--mc-emerald)]"
+                  >
+                    {crumb.label}
+                  </Link>
+                ) : (
+                  <span
+                    className={cn(
+                      'truncate',
+                      isLast ? 'text-[var(--mc-emerald)]' : 'text-gray-400',
+                    )}
+                  >
+                    {crumb.label}
+                  </span>
+                )}
+              </span>
+            );
+          })}
+        </nav>
 
-        <div className="mc-slot hidden sm:flex items-center gap-2 px-3 py-1.5">
-          <div className="w-2 h-2 bg-emerald-400 rounded-full animate-pulse" />
-          <span className="text-xs text-emerald-200 font-minecraft">{t("systemActive")}</span>
-        </div>
+        <div className="ml-auto flex shrink-0 items-center gap-2">
+          <GitHubStarButton label={t('github')} />
 
-        <div className="relative" ref={menuRef}>
-          <button
-            type="button"
-            onClick={() => setShowUserMenu(!showUserMenu)}
-            className={cn(
-              "flex items-center gap-3 px-2.5 py-1.5 border-2 transition-colors font-minecraft",
-              showUserMenu ? "border-[var(--mc-frame)] bg-emerald-600/20" : "border-transparent hover:border-[var(--mc-frame)] hover:bg-black/30",
-            )}
+          <div
+            className="mc-slot hidden h-11 w-11 items-center justify-center sm:flex"
+            title={t('systemActive')}
           >
-            <div className="mc-slot h-9 w-9 flex items-center justify-center overflow-hidden">
-              <Image src="/images/player-head.png" alt="User" width={28} height={28} className="pixelated object-cover" />
-            </div>
-            <div className="hidden md:block text-left leading-tight">
-              <p className="text-sm font-medium text-white">{sessionUser?.username || "..."}</p>
-              <p className="text-[11px] text-gray-400">{sessionUser?.role === "ADMIN" ? t("administrator") : t("userLabel")}</p>
-            </div>
-            <ChevronDown className={cn("h-4 w-4 text-gray-400 transition-transform duration-200", showUserMenu && "rotate-180")} />
-          </button>
+            <span className="sr-only">{t('systemActive')}</span>
+            <span
+              className="h-2.5 w-2.5 animate-pulse rounded-full bg-emerald-400 shadow-[0_0_8px_var(--mc-emerald)]"
+              aria-hidden="true"
+            />
+          </div>
+
+          <div className="relative" ref={menuRef}>
+            <button
+              type="button"
+              onClick={() => setShowUserMenu(!showUserMenu)}
+              className={cn(
+                'flex h-11 items-center gap-2 border-2 px-2 transition-colors font-minecraft',
+                showUserMenu
+                  ? 'border-[var(--mc-frame)] bg-emerald-600/20'
+                  : 'border-transparent hover:border-[var(--mc-frame)] hover:bg-black/30',
+              )}
+            >
+              <div className="mc-slot flex h-8 w-8 items-center justify-center overflow-hidden">
+                <Image
+                  src="/images/player-head.png"
+                  alt="User"
+                  width={24}
+                  height={24}
+                  className="pixelated object-cover"
+                />
+              </div>
+              <span className="hidden max-w-32 truncate text-sm text-white md:block">
+                {sessionUser?.username || '...'}
+              </span>
+              <ChevronDown
+                className={cn(
+                  'h-4 w-4 text-gray-400 transition-transform duration-200',
+                  showUserMenu && 'rotate-180',
+                )}
+              />
+            </button>
 
             {/* Dropdown menu with CSS transitions */}
-            <div className={cn(
-              "absolute right-0 mt-2 w-56 z-50 bg-[var(--mc-stone)] border-2 border-[var(--mc-frame)]",
-              "shadow-[inset_2px_2px_0_rgba(255,255,255,0.1),inset_-2px_-2px_0_rgba(0,0,0,0.5),0_8px_24px_rgba(0,0,0,0.55)]",
-              "transition-all duration-200 origin-top-right",
-              showUserMenu ? "opacity-100 scale-100 pointer-events-auto" : "opacity-0 scale-95 pointer-events-none"
-            )}>
+            <div
+              className={cn(
+                'absolute right-0 mt-2 w-56 z-50 bg-[var(--mc-stone)] border-2 border-[var(--mc-frame)]',
+                'shadow-[inset_2px_2px_0_rgba(255,255,255,0.1),inset_-2px_-2px_0_rgba(0,0,0,0.5),0_8px_24px_rgba(0,0,0,0.55)]',
+                'transition-all duration-200 origin-top-right',
+                showUserMenu
+                  ? 'opacity-100 scale-100 pointer-events-auto'
+                  : 'opacity-0 scale-95 pointer-events-none',
+              )}
+            >
               <div className="mc-titlebar flex items-center gap-3 p-4">
-                <div className="h-10 w-10 rounded-full bg-emerald-600 flex items-center justify-center overflow-hidden">
-                  <Image src="/images/player-head.png" alt="User" width={40} height={40} className="rounded-full object-cover" />
+                <div className="mc-slot flex h-10 w-10 items-center justify-center overflow-hidden">
+                  <Image
+                    src="/images/player-head.png"
+                    alt="User"
+                    width={28}
+                    height={28}
+                    className="pixelated object-cover"
+                  />
                 </div>
-                <div>
-                  <p className="font-medium font-minecraft text-white">{sessionUser?.username || "..."}</p>
+                <div className="min-w-0">
+                  <p className="truncate font-medium font-minecraft text-white">
+                    {sessionUser?.username || '...'}
+                  </p>
+                  <p className="text-[11px] text-gray-400">
+                    {sessionUser?.role === 'ADMIN' ? t('administrator') : t('userLabel')}
+                  </p>
                 </div>
               </div>
               <div className="flex flex-row items-center py-1 text-white px-2">
-                <LanguageSwitcher /> <p className="px-2">{t("changeLanguage")}</p>
+                <LanguageSwitcher /> <p className="px-2">{t('changeLanguage')}</p>
               </div>
               <div className="py-2">
-                <button onClick={handleLogout} className="w-full flex items-center gap-3 px-4 py-3 text-sm text-red-400 hover:bg-red-600/20 transition-colors">
+                <button
+                  onClick={handleLogout}
+                  className="w-full flex items-center gap-3 px-4 py-3 text-sm text-red-400 hover:bg-red-600/20 transition-colors"
+                >
                   <LogOut className="h-4 w-4" />
-                  {t("logout")}
+                  {t('logout')}
                 </button>
               </div>
             </div>
           </div>
-
-          <div className="hidden lg:flex items-center gap-2">
-            <div className="animate-float">
-              <Image src="/images/diamond.webp" alt="Diamond" width={24} height={24} className="opacity-70" />
-            </div>
-          </div>
         </div>
+      </div>
     </header>
   );
 }

--- a/frontend/src/lib/translations/de.ts
+++ b/frontend/src/lib/translations/de.ts
@@ -1732,4 +1732,6 @@ export const de: Record<TranslationKey, string> = {
   tabGroupOperation: 'Betrieb',
   tabGroupMonitoring: 'Überwachung',
   back: 'Zurück',
+  pageNotFoundTitle: 'Seite nicht gefunden',
+  pageNotFoundDesc: 'Diese Seite existiert nicht oder wurde verschoben.',
 };

--- a/frontend/src/lib/translations/en.ts
+++ b/frontend/src/lib/translations/en.ts
@@ -1702,6 +1702,8 @@ export const en = {
   tabGroupOperation: 'Operation',
   tabGroupMonitoring: 'Monitoring',
   back: 'Back',
+  pageNotFoundTitle: 'Page not found',
+  pageNotFoundDesc: 'This page does not exist or has been moved.',
 };
 
 export type TranslationKey = keyof typeof en;

--- a/frontend/src/lib/translations/es.ts
+++ b/frontend/src/lib/translations/es.ts
@@ -1727,4 +1727,6 @@ export const es: Record<TranslationKey, string> = {
   tabGroupOperation: 'Operación',
   tabGroupMonitoring: 'Monitoreo',
   back: 'Volver',
+  pageNotFoundTitle: 'Página no encontrada',
+  pageNotFoundDesc: 'Esta página no existe o fue movida.',
 };

--- a/frontend/src/lib/translations/fr.ts
+++ b/frontend/src/lib/translations/fr.ts
@@ -1705,4 +1705,6 @@ export const fr: Record<TranslationKey, string> = {
   tabGroupOperation: 'Opération',
   tabGroupMonitoring: 'Surveillance',
   back: 'Retour',
+  pageNotFoundTitle: 'Page introuvable',
+  pageNotFoundDesc: "Cette page n'existe pas ou a été déplacée.",
 };

--- a/frontend/src/lib/translations/nl.ts
+++ b/frontend/src/lib/translations/nl.ts
@@ -1738,4 +1738,6 @@ export const nl: Record<TranslationKey, string> = {
   tabGroupOperation: 'Beheer',
   tabGroupMonitoring: 'Monitoring',
   back: 'Terug',
+  pageNotFoundTitle: 'Pagina niet gevonden',
+  pageNotFoundDesc: 'Deze pagina bestaat niet of is verplaatst.',
 };

--- a/frontend/src/lib/translations/pl.ts
+++ b/frontend/src/lib/translations/pl.ts
@@ -1729,4 +1729,6 @@ export const pl: Record<TranslationKey, string> = {
   tabGroupOperation: 'Obsługa',
   tabGroupMonitoring: 'Monitorowanie',
   back: 'Wstecz',
+  pageNotFoundTitle: 'Nie znaleziono strony',
+  pageNotFoundDesc: 'Ta strona nie istnieje lub została przeniesiona.',
 };

--- a/frontend/src/lib/translations/pt.ts
+++ b/frontend/src/lib/translations/pt.ts
@@ -1727,4 +1727,6 @@ export const pt: Record<TranslationKey, string> = {
   tabGroupOperation: 'Operação',
   tabGroupMonitoring: 'Monitoramento',
   back: 'Voltar',
+  pageNotFoundTitle: 'Página não encontrada',
+  pageNotFoundDesc: 'Esta página não existe ou foi movida.',
 };

--- a/frontend/src/lib/translations/ru.ts
+++ b/frontend/src/lib/translations/ru.ts
@@ -1704,4 +1704,6 @@ export const ru: Record<TranslationKey, string> = {
   tabGroupOperation: 'Управление',
   tabGroupMonitoring: 'Мониторинг',
   back: 'Назад',
+  pageNotFoundTitle: 'Страница не найдена',
+  pageNotFoundDesc: 'Эта страница не существует или была перемещена.',
 };


### PR DESCRIPTION
## Why

The server dashboard was the weakest screen in the app: every row carried a full-size emerald `CONFIGURE` button, so the primary color stopped meaning anything and six identical green blocks dominated the page. The header pushed everything into the right edge, left its whole left half empty, and hung a floating diamond outside its container. Unmatched routes fell through to the stock Next.js 404.

## Server rows (`src/app/dashboard/servers/page.tsx`)

- The whole row is now a stretched link to the server config, with a hover lift, emerald shadow and a `→` that slides in. The repeated green buttons are gone, so emerald means "create server" again.
- Clone and delete become quiet 32px icon buttons that only reveal their bevel on hover; red now appears only when hovering delete.
- Port/container render as mono `:25566` / `cobbleverse`, right-aligned; smaller status badge, 48px → 40px icon, tighter gaps. Row height ~92px → ~68px.
- Dropped the status dot layered on the item icon — the side stripe and the badge already said it twice.
- `CREATE SERVER` drops to `text-sm`.

## Header (`src/components/organisms/DashboardHeader.tsx`)

- Breadcrumb on the left, derived from `pathname` and reusing the i18n keys the sidebar already has (`home`, `dashboard`, `files`, `worldLibrary`, `templates`, `settings`). On `/dashboard/servers/[id]` it shows `DASHBOARD / <name>` from `useServerNavStore`, with the first segment linking back.
- The `SYSTEM ACTIVE` chip becomes a pulsing dot in an `mc-slot`, keeping `title` + `sr-only` text.
- Compact user chip (32px avatar, one-line name); the role moved into the dropdown. Header 64px → 56px.
- Removed the floating diamond, which was also mis-nested inside the user menu container rather than the header.
- `GitHubStarButton` untouched.

## 404 page (`src/app/not-found.tsx`, new)

Replaces the stock black "This page could not be found" screen with an `mc-panel` (titlebar, barrier icon, big 404) and links back to home and the server dashboard. Adds `pageNotFoundTitle` / `pageNotFoundDesc` to all 8 dictionaries.

## Styles (`src/app/globals.css`)

New `.mc-iconbtn` (+ `--danger` modifier) alongside the rest of the `mc-*` system.

## Note for reviewers

The `.mc-*` block lives **outside any `@layer`**, so rules like `.mc-panel > *` (`position: relative; z-index: 1`) beat Tailwind utilities regardless of specificity. That's why the row wraps its content in a single child: as a direct child of `.mc-panel`, the `absolute inset-0` link would collapse to zero size and the row would not be clickable. It's commented in the JSX. Moving that block into `@layer components` would remove the trap, but that's a separate change.

## Verification

`tsc --noEmit` and `eslint src` clean; new files pass Prettier. Rendered against a dev server built from this branch: `/esta-ruta-no-existe` returns 404 with the new panel markup, `/dashboard/servers` compiles and returns 200. The dashboard itself sits behind auth and the backend was not running locally, so the row layout has not been eyeballed in a browser.

Note: the translation dictionaries were already not Prettier-formatted before this branch, so they were left as-is rather than reformatted — the diff there is 2 added lines per file.