### PR TITLE
feat(frontend): rebuild the End easter egg scene

### DIFF
--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -384,10 +384,10 @@
 @keyframes wing-flap {
   0%,
   100% {
-    transform: translateZ(var(--wing-z, 0px)) rotateX(calc(var(--flap-dir, 1) * 55deg));
+    transform: translateZ(var(--wing-z, 0px)) rotateX(calc(var(--flap-dir, 1) * var(--flap-lo, 55deg)));
   }
   50% {
-    transform: translateZ(var(--wing-z, 0px)) rotateX(calc(var(--flap-dir, 1) * 125deg));
+    transform: translateZ(var(--wing-z, 0px)) rotateX(calc(var(--flap-dir, 1) * var(--flap-hi, 125deg)));
   }
 }
 

--- a/frontend/src/components/organisms/settings/EndPortalEasterEgg.tsx
+++ b/frontend/src/components/organisms/settings/EndPortalEasterEgg.tsx
@@ -49,8 +49,9 @@ interface CuboidPalette {
   readonly face: string;
 }
 
-const DRAGON_SCALES: CuboidPalette = { top: '#34343f', side: '#202028', face: '#15151b' };
-const DRAGON_DARK: CuboidPalette = { top: '#26262e', side: '#18181f', face: '#101015' };
+const DRAGON_SCALES: CuboidPalette = { top: '#2e2939', side: '#1e1a29', face: '#15121d' };
+const DRAGON_DARK: CuboidPalette = { top: '#211d2b', side: '#15121d', face: '#0d0b13' };
+const DRAGON_MEMBRANE = 'linear-gradient(150deg, #3a2f4e 0%, #291f3a 45%, #17121f 100%)';
 
 interface CuboidProps {
   readonly w: number;
@@ -279,32 +280,90 @@ function WarpOverlay() {
   );
 }
 
+const WING_BONE = '#15121d';
+
 function DragonWing({ front }: { readonly front: boolean }) {
+  const direction = front ? '1' : '-1';
   return (
     <div
-      className="animate-wing-flap motion-reduce:[animation-play-state:paused] absolute"
+      className="animate-wing-flap motion-reduce:[animation-play-state:paused] absolute [transform-style:preserve-3d]"
       style={
         {
-          width: 74,
-          height: 104,
-          left: 64,
-          top: 28,
-          '--wing-z': front ? '16px' : '-16px',
-          '--flap-dir': front ? '1' : '-1',
-          clipPath: 'polygon(12% 0, 55% 4%, 100% 34%, 88% 100%, 62% 66%, 38% 96%, 16% 58%, 0 78%, 2% 22%)',
-          background: 'linear-gradient(155deg, rgba(129,57,181,0.9), rgba(49,35,102,0.92) 45%, rgba(18,16,26,0.96) 85%)',
-          borderTop: '3px solid #26262e',
+          left: 106,
+          top: 46,
+          width: 72,
+          height: 94,
+          '--wing-z': front ? '17px' : '-17px',
+          '--flap-dir': direction,
+          '--flap-lo': '44deg',
+          '--flap-hi': '114deg',
         } as React.CSSProperties
       }
     >
-      <div className="absolute left-[6%] top-[2%] h-[3px] w-[92%] bg-[#26262e]" style={{ transform: 'rotate(20deg)', transformOrigin: 'left center' }} />
-      <div className="absolute left-[6%] top-[2%] h-[3px] w-[76%] bg-[#26262e]" style={{ transform: 'rotate(42deg)', transformOrigin: 'left center' }} />
-      <div className="absolute left-[6%] top-[2%] h-[3px] w-[62%] bg-[#26262e]" style={{ transform: 'rotate(64deg)', transformOrigin: 'left center' }} />
+      <div className="absolute left-0 top-0 h-[7px] w-full" style={{ background: WING_BONE }} />
+      <div
+        className="absolute left-0 top-[5px] h-[89px] w-[72px]"
+        style={{
+          background: DRAGON_MEMBRANE,
+          clipPath:
+            'polygon(0 0, 100% 0, 100% 18%, 86% 18%, 86% 36%, 70% 36%, 70% 54%, 52% 54%, 52% 70%, 32% 70%, 32% 86%, 14% 86%, 14% 100%, 0 100%)',
+        }}
+      />
+      {[
+        { rotate: 24, width: 66 },
+        { rotate: 46, width: 52 },
+        { rotate: 68, width: 40 },
+      ].map((bone) => (
+        <div
+          key={bone.rotate}
+          className="absolute left-[2px] top-[4px] h-[3px]"
+          style={{ width: bone.width, background: WING_BONE, transform: `rotate(${bone.rotate}deg)`, transformOrigin: 'left center' }}
+        />
+      ))}
+      <div
+        className="animate-wing-flap motion-reduce:[animation-play-state:paused] absolute [transform-style:preserve-3d]"
+        style={
+          {
+            left: 64,
+            top: 0,
+            width: 54,
+            height: 68,
+            animationDelay: '-0.22s',
+            transformOrigin: 'left top',
+            '--wing-z': '0px',
+            '--flap-dir': direction,
+            '--flap-lo': '10deg',
+            '--flap-hi': '40deg',
+          } as React.CSSProperties
+        }
+      >
+        <div className="absolute left-0 top-0 h-[6px] w-full" style={{ background: WING_BONE }} />
+        <div
+          className="absolute left-0 top-[4px] h-[64px] w-[54px]"
+          style={{
+            background: DRAGON_MEMBRANE,
+            clipPath: 'polygon(0 0, 100% 0, 100% 22%, 80% 22%, 80% 44%, 58% 44%, 58% 66%, 32% 66%, 32% 86%, 0 86%)',
+          }}
+        />
+      </div>
     </div>
   );
 }
 
-function TailSegment({ left, top, size, delay, swayDir }: { readonly left: number; readonly top: number; readonly size: number; readonly delay: number; readonly swayDir: 1 | -1 }) {
+interface SwaySegmentProps {
+  readonly left: number;
+  readonly top: number;
+  readonly w: number;
+  readonly h: number;
+  readonly d: number;
+  readonly delay: number;
+  readonly swayDir: 1 | -1;
+  readonly origin: string;
+  readonly palette?: CuboidPalette;
+  readonly children?: React.ReactNode;
+}
+
+function SwaySegment({ left, top, w, h, d, delay, swayDir, origin, palette = DRAGON_SCALES, children }: SwaySegmentProps) {
   return (
     <div
       className="animate-tail-sway motion-reduce:[animation-play-state:paused] absolute [transform-style:preserve-3d]"
@@ -312,16 +371,22 @@ function TailSegment({ left, top, size, delay, swayDir }: { readonly left: numbe
         {
           left,
           top,
-          width: size + 6,
-          height: size,
+          width: w,
+          height: h,
+          transformOrigin: origin,
           animationDelay: `${delay}s`,
           '--sway-dir': `${swayDir}`,
         } as React.CSSProperties
       }
     >
-      <Cuboid w={size + 6} h={size} d={size} palette={size < 14 ? DRAGON_DARK : DRAGON_SCALES} style={{ left: 0, top: 0 }} />
+      <Cuboid w={w} h={h} d={d} palette={palette} style={{ left: 0, top: 0 }} />
+      {children}
     </div>
   );
+}
+
+function DorsalSpike({ left, top, size = 1 }: { readonly left: number; readonly top: number; readonly size?: number }) {
+  return <Cuboid w={6 * size} h={9 * size} d={5 * size} palette={DRAGON_DARK} style={{ left, top }} />;
 }
 
 function DragonLeg({ left, top, length, z, delay }: { readonly left: number; readonly top: number; readonly length: number; readonly z: number; readonly delay: number }) {
@@ -347,55 +412,70 @@ function DragonLeg({ left, top, length, z, delay }: { readonly left: number; rea
 
 function VoxelEnderDragon() {
   return (
-    <div aria-hidden className="relative h-[120px] w-[210px] [perspective:900px]">
-      <div className="absolute left-1/2 top-1/2 h-24 w-40 -translate-x-1/2 -translate-y-1/2 rounded-full bg-purple-600/25 blur-2xl" />
-      <div className="absolute inset-0 [transform-style:preserve-3d]" style={{ transform: 'rotateY(-32deg) rotateX(12deg)' }}>
-        {/* tail, thinning toward the back, wagging in a staggered wave */}
-        <TailSegment left={0} top={47} size={9} delay={0.6} swayDir={1} />
-        <TailSegment left={14} top={44} size={12} delay={0.4} swayDir={-1} />
-        <TailSegment left={36} top={40} size={15} delay={0.2} swayDir={1} />
-        {/* body */}
-        <Cuboid w={64} h={30} d={30} palette={DRAGON_SCALES} style={{ left: 64, top: 30 }} />
-        {/* dorsal spikes */}
-        <Cuboid w={6} h={7} d={4} palette={DRAGON_DARK} style={{ left: 74, top: 23 }} />
-        <Cuboid w={6} h={7} d={4} palette={DRAGON_DARK} style={{ left: 90, top: 23 }} />
-        <Cuboid w={6} h={7} d={4} palette={DRAGON_DARK} style={{ left: 106, top: 23 }} />
-        {/* legs */}
-        <DragonLeg left={80} top={58} length={20} z={10} delay={0.2} />
-        <DragonLeg left={80} top={58} length={20} z={-10} delay={0.7} />
-        <DragonLeg left={114} top={56} length={16} z={9} delay={0.5} />
-        <DragonLeg left={114} top={56} length={16} z={-9} delay={1} />
-        {/* neck + head + snout */}
-        <Cuboid w={24} h={14} d={14} palette={DRAGON_SCALES} style={{ left: 124, top: 30 }} />
-        <Cuboid w={5} h={6} d={4} palette={DRAGON_DARK} style={{ left: 130, top: 24 }} />
-        <Cuboid w={28} h={16} d={18} palette={DRAGON_SCALES} style={{ left: 146, top: 26 }}>
-          {/* glowing eyes on both sides of the head */}
-          <div
-            className="absolute"
-            style={{ width: 5, height: 3, left: 19, top: 5, transform: 'translateZ(10px)', background: '#e879f9', boxShadow: '0 0 8px #d946ef' }}
-          />
-          <div
-            className="absolute"
-            style={{ width: 5, height: 3, left: 19, top: 5, transform: 'rotateY(180deg) translateZ(10px)', background: '#e879f9', boxShadow: '0 0 8px #d946ef' }}
-          />
+    <div aria-hidden className="relative h-[150px] w-[270px] [perspective:1100px]">
+      <div className="absolute left-1/2 top-1/2 h-28 w-56 -translate-x-1/2 -translate-y-1/2 rounded-full bg-purple-600/25 blur-2xl" />
+      <div className="absolute inset-0 [transform-style:preserve-3d]" style={{ transform: 'rotateY(-26deg) rotateX(10deg)' }}>
+        <SwaySegment left={0} top={72} w={16} h={7} d={7} delay={1} swayDir={-1} origin="100% 50%" palette={DRAGON_DARK}>
+          <div className="absolute" style={{ left: -4, top: -7, width: 11, height: 20, background: '#2a2338' }} />
+        </SwaySegment>
+        <SwaySegment left={14} top={69} w={18} h={10} d={10} delay={0.8} swayDir={1} origin="100% 50%" palette={DRAGON_DARK} />
+        <SwaySegment left={30} top={66} w={20} h={13} d={13} delay={0.6} swayDir={-1} origin="100% 50%">
+          <DorsalSpike left={7} top={-6} size={0.6} />
+        </SwaySegment>
+        <SwaySegment left={48} top={62} w={22} h={16} d={16} delay={0.4} swayDir={1} origin="100% 50%">
+          <DorsalSpike left={8} top={-7} size={0.75} />
+        </SwaySegment>
+        <SwaySegment left={68} top={58} w={24} h={20} d={20} delay={0.2} swayDir={-1} origin="100% 50%">
+          <DorsalSpike left={9} top={-8} size={0.85} />
+        </SwaySegment>
+        <Cuboid w={66} h={28} d={30} palette={DRAGON_SCALES} style={{ left: 90, top: 52 }} />
+        <Cuboid w={54} h={10} d={26} palette={DRAGON_DARK} style={{ left: 96, top: 72 }} />
+        <DorsalSpike left={100} top={44} />
+        <DorsalSpike left={116} top={43} />
+        <DorsalSpike left={132} top={44} />
+        <DorsalSpike left={146} top={46} size={0.85} />
+        <DragonLeg left={106} top={80} length={22} z={12} delay={0.2} />
+        <DragonLeg left={106} top={80} length={22} z={-12} delay={0.7} />
+        <DragonLeg left={138} top={78} length={17} z={11} delay={0.5} />
+        <DragonLeg left={138} top={78} length={17} z={-11} delay={1} />
+        <SwaySegment left={154} top={48} w={24} h={18} d={18} delay={0.15} swayDir={1} origin="0% 50%">
+          <DorsalSpike left={9} top={-6} size={0.6} />
+        </SwaySegment>
+        <SwaySegment left={176} top={42} w={22} h={15} d={15} delay={0.35} swayDir={-1} origin="0% 50%">
+          <DorsalSpike left={8} top={-6} size={0.55} />
+        </SwaySegment>
+        <SwaySegment left={196} top={37} w={20} h={13} d={13} delay={0.55} swayDir={1} origin="0% 50%" />
+        <Cuboid w={30} h={20} d={22} palette={DRAGON_SCALES} style={{ left: 212, top: 28 }}>
+          {[1, -1].map((side) => (
+            <div
+              key={side}
+              className="absolute"
+              style={{
+                width: 7,
+                height: 4,
+                left: 19,
+                top: 6,
+                transform: side === 1 ? 'translateZ(12px)' : 'rotateY(180deg) translateZ(12px)',
+                background: '#f0abfc',
+                boxShadow: '0 0 10px #d946ef',
+              }}
+            />
+          ))}
         </Cuboid>
-        <Cuboid w={12} h={7} d={12} palette={DRAGON_DARK} style={{ left: 172, top: 31 }} />
-        <Cuboid w={10} h={4} d={10} palette={DRAGON_DARK} style={{ left: 172, top: 40 }} />
-        {/* horns */}
-        <Cuboid w={9} h={4} d={4} palette={DRAGON_DARK} style={{ left: 148, top: 22, transform: 'translateZ(5px)' }} />
-        <Cuboid w={9} h={4} d={4} palette={DRAGON_DARK} style={{ left: 148, top: 22, transform: 'translateZ(-5px)' }} />
-        {/* wings */}
+        <Cuboid w={16} h={11} d={16} palette={DRAGON_DARK} style={{ left: 238, top: 32 }} />
+        <SwaySegment left={236} top={44} w={17} h={6} d={14} delay={0} swayDir={1} origin="0% 50%" palette={DRAGON_DARK} />
+        <Cuboid w={11} h={5} d={5} palette={DRAGON_DARK} style={{ left: 214, top: 22, transform: 'translateZ(7px) rotateZ(-14deg)' }} />
+        <Cuboid w={11} h={5} d={5} palette={DRAGON_DARK} style={{ left: 214, top: 22, transform: 'translateZ(-7px) rotateZ(-14deg)' }} />
         <DragonWing front />
         <DragonWing front={false} />
-        {/* dragon breath particles streaming from the snout */}
         {[0, 1, 2, 3].map((index) => (
           <div
             key={index}
             className="animate-dragon-breath motion-reduce:animate-none absolute h-[4px] w-[4px] rounded-[1px] bg-fuchsia-400"
             style={
               {
-                left: 186,
-                top: 32 + index * 2,
+                left: 254,
+                top: 36 + index * 2,
                 animationDelay: `${index * 0.4}s`,
                 boxShadow: '0 0 6px #d946ef',
                 '--breath-y': `${(index - 1.5) * 9}px`,
@@ -772,6 +852,7 @@ function EndScene({ onReturn, reducedMotion }: EndSceneProps) {
   const starLayerRef = useRef<HTMLDivElement>(null);
   const midLayerRef = useRef<HTMLDivElement>(null);
   const [isDesktop, setIsDesktop] = useState(false);
+  const scene3d = !reducedMotion && isDesktop;
 
   useEffect(() => {
     const media = window.matchMedia('(min-width: 1024px) and (pointer: fine)');
@@ -828,24 +909,25 @@ function EndScene({ onReturn, reducedMotion }: EndSceneProps) {
       exit={{ opacity: 0, transition: { duration: 0.4 } }}
       onMouseMove={onMouseMove}
     >
-      {!reducedMotion && isDesktop && <EndWorldScene onReturn={onReturn} />}
+      {scene3d && <EndWorldScene onReturn={onReturn} />}
       <div className="pointer-events-none absolute inset-0 [perspective:1400px]">
       <div ref={lookRef} className="absolute inset-0 transition-transform duration-300 ease-out will-change-transform">
       <div ref={starLayerRef} aria-hidden className="absolute -inset-8 transition-transform duration-300 ease-out">
-        {stars.map((star) => (
-          <div
-            key={star.id}
-            className="animate-twinkle motion-reduce:animate-none absolute rounded-[1px] bg-purple-100/90"
-            style={{
-              top: `${star.top}%`,
-              left: `${star.left}%`,
-              width: `${star.size}px`,
-              height: `${star.size}px`,
-              animationDelay: `${star.delay}s`,
-              animationDuration: `${star.duration}s`,
-            }}
-          />
-        ))}
+        {!scene3d &&
+          stars.map((star) => (
+            <div
+              key={star.id}
+              className="animate-twinkle motion-reduce:animate-none absolute rounded-[1px] bg-purple-100/90"
+              style={{
+                top: `${star.top}%`,
+                left: `${star.left}%`,
+                width: `${star.size}px`,
+                height: `${star.size}px`,
+                animationDelay: `${star.delay}s`,
+                animationDuration: `${star.duration}s`,
+              }}
+            />
+          ))}
         {particles.map((particle) => (
           <div
             key={particle.id}
@@ -859,13 +941,15 @@ function EndScene({ onReturn, reducedMotion }: EndSceneProps) {
         ))}
       </div>
       <div aria-hidden className="absolute inset-0">
-        <m.div
-          className="absolute top-[14%] left-0 scale-90 md:scale-110"
-          animate={reducedMotion ? undefined : { x: ['-30vw', '110vw'], y: [0, -70, 40, -30, 0], rotate: [0, -6, 5, -4, 0] }}
-          transition={{ duration: 20, repeat: Infinity, ease: 'linear' }}
-        >
-          <VoxelEnderDragon />
-        </m.div>
+        {!scene3d && (
+          <m.div
+            className="absolute top-[14%] left-0 scale-90 md:scale-110"
+            animate={reducedMotion ? undefined : { x: ['-30vw', '110vw'], y: [0, -70, 40, -30, 0], rotate: [0, -6, 5, -4, 0] }}
+            transition={{ duration: 20, repeat: Infinity, ease: 'linear' }}
+          >
+            <VoxelEnderDragon />
+          </m.div>
+        )}
         {/* enderman tumbling helplessly through the void, opposite direction to the dragon */}
         <m.div
           className="absolute top-[48%] left-0 scale-75 md:scale-90"
@@ -879,7 +963,7 @@ function EndScene({ onReturn, reducedMotion }: EndSceneProps) {
           <VoxelEnderman />
         </m.div>
       </div>
-      <div ref={midLayerRef} aria-hidden className="absolute inset-0 transition-transform duration-300 ease-out">
+      <div ref={midLayerRef} aria-hidden className={`absolute inset-0 transition-transform duration-300 ease-out ${scene3d ? 'hidden' : ''}`}>
         <div className="absolute right-[24%] top-[5%] hidden md:block">
           <EndCityTower />
         </div>
@@ -930,7 +1014,11 @@ function EndScene({ onReturn, reducedMotion }: EndSceneProps) {
         <p className="font-minecraft text-[10px] tracking-[0.18em] text-fuchsia-300">{t('dangerEggMission')}</p>
         <p className="mt-1 font-minecraft text-sm text-purple-100">{t('dangerEggMissionObjective')}</p>
       </div>
-      <div className="pointer-events-none relative flex h-full flex-col items-center justify-center gap-4 px-6 text-center">
+      <div
+        className={`pointer-events-none relative flex h-full flex-col items-center gap-4 px-6 text-center ${
+          scene3d ? 'justify-end pb-12' : 'justify-center'
+        }`}
+      >
         <m.h2
           className="font-minecraft drop-shadow-glow text-4xl text-purple-200 md:text-5xl"
           initial={{ opacity: 0, y: 20 }}

--- a/frontend/src/components/organisms/settings/EndWorldScene.tsx
+++ b/frontend/src/components/organisms/settings/EndWorldScene.tsx
@@ -1,176 +1,301 @@
 'use client';
 
-import { Sparkles } from '@react-three/drei';
+import { Instance, Instances, Sparkles, Stars } from '@react-three/drei';
 import { Canvas, useFrame, useThree } from '@react-three/fiber';
 import { useEffect, useMemo, useRef, useState } from 'react';
 import * as THREE from 'three';
 
-const STONE = '#d3c985';
-const STONE_DARK = '#8c8555';
-const OBSIDIAN = '#1a1029';
-const PURPUR = '#9d6faf';
-const PORTAL_FRAME = [
-  [-1, -2], [0, -2], [1, -2],
-  [-1, 2], [0, 2], [1, 2],
-  [-2, -1], [-2, 0], [-2, 1],
-  [2, -1], [2, 0], [2, 1],
+const UNIT_BOX = new THREE.BoxGeometry(1, 1, 1);
+const OCTAHEDRON = new THREE.OctahedronGeometry(1, 0);
+// beam geometry points down +Z and starts at the origin, so a mesh can be
+// placed on the emitter, aimed with lookAt() and stretched with scale.z
+const BEAM = new THREE.CylinderGeometry(1, 1, 1, 6).rotateX(Math.PI / 2).translate(0, 0, 0.5);
+
+const END_STONE_SHADES = ['#e8e2b4', '#dcd5a4', '#cec692', '#bdb47c', '#a89f6b'];
+const CHORUS_SHADES = ['#9a63b4', '#84509c', '#6d4083'];
+const BEDROCK_SHADES = ['#3a3a42', '#2c2c33', '#22222a'];
+
+const MAIN_ISLAND_LAYERS = [10, 9.7, 9, 7.9, 6.4, 4.8, 3.2, 1.8];
+const FAR_ISLAND_LAYERS = [4.4, 4, 3.2, 2.1, 1];
+
+const PILLARS = [
+  { angle: 0.2, radius: 8.8, height: 9, crystal: true, light: true },
+  { angle: 0.95, radius: 9.4, height: 6, crystal: false, light: false },
+  { angle: 1.8, radius: 8.6, height: 11, crystal: true, light: false },
+  { angle: 2.6, radius: 9.2, height: 7, crystal: false, light: false },
+  { angle: 3.4, radius: 8.9, height: 10, crystal: true, light: true },
+  { angle: 4.2, radius: 9.3, height: 6.5, crystal: false, light: false },
+  { angle: 5.05, radius: 8.7, height: 12, crystal: true, light: false },
+  { angle: 5.8, radius: 9.4, height: 8, crystal: false, light: false },
 ] as const;
 
-function CameraDrift({ returning }: { readonly returning: boolean }) {
-  const { camera, pointer } = useThree();
-  const target = useMemo(() => new THREE.Vector3(), []);
-  const portalPosition = useMemo(() => new THREE.Vector3(0.2, -1.1, -18.2), []);
+const DRAGON_ORBIT = 17;
+const DRAGON_HEIGHT = 15;
 
-  useFrame(({ clock }, delta) => {
-    const time = clock.getElapsedTime();
-    if (returning) {
-      camera.position.lerp(portalPosition, 1 - Math.exp(-delta * 1.5));
-      if (camera instanceof THREE.PerspectiveCamera) {
-        camera.fov += (34 - camera.fov) * delta * 2;
-        camera.updateProjectionMatrix();
-      }
-      target.copy(portalPosition);
-    } else {
-      camera.position.x += (pointer.x * 1.8 - camera.position.x) * delta * 1.4;
-      camera.position.y += (1.8 + pointer.y * 0.8 - camera.position.y) * delta * 1.4;
-      camera.position.z = 13 - Math.sin(time * 0.1) * 1.5;
-      target.set(pointer.x * 1.1, pointer.y * 0.5, -18);
-    }
-    camera.lookAt(target);
-  });
-
-  return null;
+function hash2(x: number, z: number, seed: number) {
+  const value = Math.sin(x * 127.1 + z * 311.7 + seed * 74.7) * 43758.5453;
+  return value - Math.floor(value);
 }
 
-function EndIsland({ position, scale }: { readonly position: [number, number, number]; readonly scale: number }) {
-  const blocks = useMemo(
-    () =>
-      Array.from({ length: 28 }, (_, index) => {
-        const angle = index * 2.4;
-        const radius = 0.4 + (index % 7) * 0.19;
-        return {
-          key: index,
-          position: [Math.cos(angle) * radius, -Math.floor(index / 9) * 0.35, Math.sin(angle) * radius] as const,
-          size: 0.45 + (index % 3) * 0.12,
-        };
-      }),
-    []
+function pick<T>(list: readonly T[], value: number) {
+  return list[Math.min(list.length - 1, Math.floor(value * list.length))];
+}
+
+interface Voxel {
+  readonly key: string;
+  readonly position: [number, number, number];
+  readonly color: string;
+  readonly scale?: [number, number, number];
+}
+
+function buildIsland(layers: readonly number[], seed: number): Voxel[] {
+  const blocks: Voxel[] = [];
+  layers.forEach((radius, depth) => {
+    const inner = layers[depth + 1] ?? 0;
+    const limit = Math.ceil(radius);
+    for (let x = -limit; x <= limit; x += 1) {
+      for (let z = -limit; z <= limit; z += 1) {
+        const distance = Math.hypot(x, z) + (hash2(x, z, seed) - 0.5) * 1.6;
+        if (distance > radius) continue;
+        if (depth > 0 && distance < inner - 1.2) continue;
+        blocks.push({
+          key: `${depth}:${x}:${z}`,
+          position: [x, -depth, z],
+          color: pick(END_STONE_SHADES, hash2(x + depth * 13, z - depth * 7, seed + 3)),
+        });
+      }
+    }
+  });
+  return blocks;
+}
+
+function buildChorus(seed: number): Voxel[] {
+  const blocks: Voxel[] = [];
+  for (let plant = 0; plant < 9; plant += 1) {
+    const angle = hash2(plant, 1, seed) * Math.PI * 2;
+    const radius = 6 + hash2(plant, 2, seed) * 3.5;
+    const x = Math.round(Math.cos(angle) * radius);
+    const z = Math.round(Math.sin(angle) * radius);
+    const height = 1 + Math.floor(hash2(plant, 3, seed) * 3);
+    for (let step = 0; step < height; step += 1) {
+      blocks.push({
+        key: `${plant}:${step}`,
+        position: [x, 0.9 + step, z],
+        color: pick(CHORUS_SHADES, hash2(plant, step, seed + 5)),
+        scale: [0.7, 1, 0.7],
+      });
+    }
+    blocks.push({ key: `${plant}:flower`, position: [x, 0.9 + height, z], color: '#e0b6ef', scale: [0.9, 0.8, 0.9] });
+  }
+  return blocks;
+}
+
+function VoxelField({ blocks, position }: { readonly blocks: Voxel[]; readonly position?: [number, number, number] }) {
+  return (
+    <group position={position}>
+      <Instances limit={blocks.length} range={blocks.length} frustumCulled={false}>
+        <boxGeometry />
+        <meshStandardMaterial roughness={1} metalness={0} />
+        {blocks.map((block) => (
+          <Instance key={block.key} position={block.position} color={block.color} scale={block.scale} />
+        ))}
+      </Instances>
+    </group>
   );
+}
+
+function Island({ layers, seed, position, scale = 1, chorus }: { readonly layers: readonly number[]; readonly seed: number; readonly position: [number, number, number]; readonly scale?: number; readonly chorus?: boolean }) {
+  const blocks = useMemo(() => buildIsland(layers, seed), [layers, seed]);
+  const plants = useMemo(() => (chorus ? buildChorus(seed) : []), [chorus, seed]);
 
   return (
     <group position={position} scale={scale}>
-      {blocks.map((block) => (
-        <mesh key={block.key} position={block.position} castShadow receiveShadow>
-          <boxGeometry args={[block.size, block.size, block.size]} />
-          <meshStandardMaterial color={block.key % 4 === 0 ? STONE_DARK : STONE} roughness={1} />
-        </mesh>
-      ))}
-      {[[-0.7, 0.2, 0.1], [0.3, 0.35, -0.35], [0.7, 0.2, 0.35]].map(([x, y, z], index) => (
-        <mesh key={index} position={[x, y, z]}>
-          <boxGeometry args={[0.14, 0.8 + index * 0.15, 0.14]} />
-          <meshStandardMaterial color={PURPUR} roughness={0.75} />
-        </mesh>
-      ))}
+      <VoxelField blocks={blocks} position={[0, -0.5, 0]} />
+      {plants.length > 0 && <VoxelField blocks={plants} position={[0, -0.5, 0]} />}
     </group>
   );
 }
 
-function EndCrystal({ position }: { readonly position: [number, number, number] }) {
-  const group = useRef<THREE.Group>(null);
+function EndCrystal({ position, dragon, light }: { readonly position: [number, number, number]; readonly dragon: THREE.Vector3; readonly light: boolean }) {
+  const cage = useRef<THREE.Group>(null);
+  const beam = useRef<THREE.Mesh>(null);
+  const origin = useMemo(() => new THREE.Vector3(...position), [position]);
 
   useFrame(({ clock }) => {
-    if (!group.current) return;
-    group.current.rotation.y = clock.getElapsedTime() * 0.8;
-    group.current.position.y = position[1] + Math.sin(clock.getElapsedTime() * 1.6) * 0.16;
+    const time = clock.getElapsedTime();
+    if (cage.current) {
+      cage.current.rotation.y = time * 0.9;
+      cage.current.position.y = position[1] + Math.sin(time * 1.5 + position[0]) * 0.25;
+    }
+    if (beam.current) {
+      beam.current.position.copy(origin);
+      beam.current.position.y = cage.current?.position.y ?? position[1];
+      beam.current.lookAt(dragon);
+      beam.current.scale.set(0.09, 0.09, beam.current.position.distanceTo(dragon));
+      const material = beam.current.material as THREE.MeshBasicMaterial;
+      material.opacity = 0.28 + Math.sin(time * 9 + position[0]) * 0.08;
+    }
   });
 
   return (
-    <group ref={group} position={position}>
-      <mesh>
-        <octahedronGeometry args={[0.42, 0]} />
-        <meshStandardMaterial color="#f0c5ff" emissive="#c026d3" emissiveIntensity={2.5} roughness={0.15} />
+    <>
+      <group ref={cage} position={position}>
+        <mesh geometry={OCTAHEDRON} scale={0.55}>
+          <meshStandardMaterial color="#2a0c33" emissive="#f0abfc" emissiveIntensity={3.2} roughness={0.2} />
+        </mesh>
+        <mesh geometry={OCTAHEDRON} scale={1.15}>
+          <meshBasicMaterial color="#d946ef" transparent opacity={0.22} depthWrite={false} />
+        </mesh>
+        {light && <pointLight color="#e879f9" intensity={26} distance={16} decay={2} />}
+      </group>
+      <mesh ref={beam} geometry={BEAM} scale={[0.09, 0.09, 1]} renderOrder={2} raycast={() => null}>
+        <meshBasicMaterial color="#f5d0fe" transparent opacity={0.3} depthWrite={false} blending={THREE.AdditiveBlending} />
       </mesh>
-      <pointLight color="#d946ef" intensity={4} distance={6} />
-    </group>
+    </>
   );
 }
 
-function ObsidianPillar({ position, height, crystal }: { readonly position: [number, number, number]; readonly height: number; readonly crystal?: boolean }) {
+function ObsidianPillar({ angle, radius, height, crystal, light, dragon }: { readonly angle: number; readonly radius: number; readonly height: number; readonly crystal: boolean; readonly light: boolean; readonly dragon: THREE.Vector3 }) {
+  const x = Math.cos(angle) * radius;
+  const z = Math.sin(angle) * radius;
+
   return (
-    <group position={position}>
-      <mesh position={[0, height / 2, 0]} castShadow>
-        <boxGeometry args={[0.62, height, 0.62]} />
-        <meshStandardMaterial color={OBSIDIAN} roughness={0.9} />
-      </mesh>
-      <mesh position={[0, height + 0.04, 0]}>
-        <boxGeometry args={[0.78, 0.12, 0.78]} />
-        <meshStandardMaterial color="#34204f" roughness={0.8} />
-      </mesh>
-      {crystal && <EndCrystal position={[0, height + 0.7, 0]} />}
-    </group>
+    <>
+      <group position={[x, 0, z]}>
+        <mesh geometry={UNIT_BOX} position={[0, height / 2, 0]} scale={[2, height, 2]}>
+          <meshStandardMaterial color="#150c22" roughness={0.55} metalness={0.1} />
+        </mesh>
+        <mesh geometry={UNIT_BOX} position={[0, height + 0.15, 0]} scale={[2.6, 0.3, 2.6]}>
+          <meshStandardMaterial color="#2b2b33" roughness={0.9} />
+        </mesh>
+        {crystal &&
+          [
+            [-1, -1],
+            [-1, 1],
+            [1, -1],
+            [1, 1],
+          ].map(([bx, bz]) => (
+            <mesh key={`${bx}${bz}`} geometry={UNIT_BOX} position={[bx, height + 1.5, bz]} scale={[0.16, 2.4, 0.16]}>
+              <meshStandardMaterial color="#4a4a56" roughness={0.6} metalness={0.4} />
+            </mesh>
+          ))}
+      </group>
+      {crystal && <EndCrystal position={[x, height + 1.6, z]} dragon={dragon} light={light} />}
+    </>
   );
 }
 
-function Dragon() {
-  const dragon = useRef<THREE.Group>(null);
+const PORTAL_VERTEX = `
+  varying vec2 vUv;
+  void main() {
+    vUv = uv;
+    gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0);
+  }
+`;
 
-  useFrame(({ clock }) => {
-    if (!dragon.current) return;
-    const time = clock.getElapsedTime() * 0.32;
-    dragon.current.position.set(Math.sin(time) * 8, 2.8 + Math.sin(time * 1.8) * 0.7, -9 + Math.cos(time) * 3);
-    dragon.current.rotation.set(Math.sin(time * 1.8) * 0.08, -time + Math.PI, Math.cos(time * 1.8) * 0.12);
+const PORTAL_FRAGMENT = `
+  uniform float uTime;
+  uniform float uBoost;
+  varying vec2 vUv;
+
+  float hash(vec2 p) {
+    return fract(sin(dot(p, vec2(127.1, 311.7))) * 43758.5453);
+  }
+
+  vec3 starLayer(vec2 uv, float scale, float speed, vec3 tint, float seed) {
+    vec2 p = uv * scale + vec2(uTime * speed, uTime * speed * 0.7) + seed;
+    float h = hash(floor(p) + seed);
+    vec2 f = fract(p) - 0.5;
+    float star = 1.0 - smoothstep(0.0, 0.36, length(f) + h * 0.3);
+    return tint * star * (0.35 + 0.65 * h);
+  }
+
+  void main() {
+    vec2 uv = vUv - 0.5;
+    float r = length(uv) * 2.0;
+    vec3 color = vec3(0.015, 0.004, 0.04);
+    color += starLayer(uv, 16.0, 0.03, vec3(0.62, 0.36, 0.98), 1.0);
+    color += starLayer(uv, 10.0, -0.045, vec3(0.32, 0.86, 0.72), 7.0);
+    color += starLayer(uv, 6.0, 0.06, vec3(0.96, 0.88, 1.0), 13.0);
+    color += vec3(0.36, 0.12, 0.58) * (1.0 - smoothstep(0.15, 1.0, r)) * (0.45 + uBoost);
+    gl_FragColor = vec4(color * (1.0 + uBoost * 2.0), 1.0 - smoothstep(0.86, 1.0, r));
+  }
+`;
+
+const BEAM_VERTEX = `
+  varying vec2 vUv;
+  varying vec3 vNormal;
+  varying vec3 vView;
+  void main() {
+    vUv = uv;
+    vec4 viewPosition = modelViewMatrix * vec4(position, 1.0);
+    vNormal = normalize(normalMatrix * normal);
+    vView = normalize(-viewPosition.xyz);
+    gl_Position = projectionMatrix * viewPosition;
+  }
+`;
+
+const BEAM_FRAGMENT = `
+  uniform float uTime;
+  uniform float uBoost;
+  varying vec2 vUv;
+  varying vec3 vNormal;
+  varying vec3 vView;
+
+  void main() {
+    float fade = pow(1.0 - vUv.y, 2.2);
+    float pulse = 0.82 + 0.18 * sin(uTime * 2.6 - vUv.y * 14.0);
+    float core = pow(abs(dot(normalize(vNormal), normalize(vView))), 1.4);
+    vec3 color = mix(vec3(0.86, 0.62, 1.0), vec3(0.36, 0.06, 0.78), vUv.y);
+    gl_FragColor = vec4(color, fade * pulse * core * (0.38 + uBoost));
+  }
+`;
+
+function buildBedrockRing(): Voxel[] {
+  const blocks: Voxel[] = [];
+  for (let x = -5; x <= 5; x += 1) {
+    for (let z = -5; z <= 5; z += 1) {
+      const distance = Math.hypot(x, z);
+      if (distance < 3.4 || distance > 4.9) continue;
+      blocks.push({ key: `${x}:${z}`, position: [x, 0.5, z], color: pick(BEDROCK_SHADES, hash2(x, z, 9)) });
+    }
+  }
+  [
+    [-4, -4],
+    [-4, 4],
+    [4, -4],
+    [4, 4],
+  ].forEach(([x, z]) => {
+    blocks.push({ key: `post:${x}:${z}:1`, position: [x, 1.5, z], color: BEDROCK_SHADES[1] });
+    blocks.push({ key: `post:${x}:${z}:2`, position: [x, 2.5, z], color: BEDROCK_SHADES[0] });
   });
-
-  return (
-    <group ref={dragon} scale={0.9}>
-      <mesh castShadow>
-        <boxGeometry args={[2.3, 0.55, 0.72]} />
-        <meshStandardMaterial color="#211a2c" roughness={0.85} />
-      </mesh>
-      <mesh position={[1.45, 0.04, 0]} castShadow>
-        <boxGeometry args={[0.75, 0.44, 0.48]} />
-        <meshStandardMaterial color="#16121d" roughness={0.9} />
-      </mesh>
-      <mesh position={[-1.65, 0, 0]} rotation={[0, 0, 0.18]}>
-        <boxGeometry args={[1.3, 0.22, 0.28]} />
-        <meshStandardMaterial color="#17121f" roughness={0.9} />
-      </mesh>
-      <mesh position={[-0.15, 0.05, 1.05]} rotation={[0.1, 0, -0.18]}>
-        <boxGeometry args={[1.55, 0.08, 1.8]} />
-        <meshStandardMaterial color="#36234a" roughness={0.85} />
-      </mesh>
-      <mesh position={[-0.15, 0.05, -1.05]} rotation={[-0.1, 0, -0.18]}>
-        <boxGeometry args={[1.55, 0.08, 1.8]} />
-        <meshStandardMaterial color="#36234a" roughness={0.85} />
-      </mesh>
-      <pointLight position={[1.75, 0.1, 0.28]} color="#f0abfc" intensity={1.2} distance={3} />
-    </group>
-  );
+  return blocks;
 }
 
-function ReturnPortal({ onActivate, returning }: { readonly onActivate: () => void; readonly returning: boolean }) {
-  const portal = useRef<THREE.Group>(null);
+function ExitPortal({ onActivate, returning }: { readonly onActivate: () => void; readonly returning: boolean }) {
   const [hovered, setHovered] = useState(false);
+  const uniforms = useMemo(() => ({ uTime: { value: 0 }, uBoost: { value: 0 } }), []);
+  const ring = useMemo(() => buildBedrockRing(), []);
 
   useEffect(() => {
-    const previousCursor = document.body.style.cursor;
     return () => {
-      document.body.style.cursor = previousCursor;
+      document.body.style.cursor = '';
     };
   }, []);
 
-  useFrame(({ clock }) => {
-    if (!portal.current) return;
-    const time = clock.getElapsedTime();
-    const scale = returning ? 4 + time % 0.5 : hovered ? 1.22 : 1;
-    portal.current.scale.setScalar(scale + Math.sin(time * 2.5) * 0.05);
+  useFrame(({ clock }, delta) => {
+    uniforms.uTime.value = clock.getElapsedTime();
+    const target = returning ? 2.4 : hovered ? 0.45 : 0;
+    uniforms.uBoost.value += (target - uniforms.uBoost.value) * Math.min(1, delta * 4);
   });
 
   return (
     <group
-      ref={portal}
-      position={[0.2, -1.1, -18.2]}
-      onClick={() => !returning && onActivate()}
+      position={[0, 0, 0]}
+      onClick={(event) => {
+        event.stopPropagation();
+        if (!returning) onActivate();
+      }}
       onPointerOver={(event) => {
         event.stopPropagation();
         setHovered(true);
@@ -181,57 +306,251 @@ function ReturnPortal({ onActivate, returning }: { readonly onActivate: () => vo
         document.body.style.cursor = '';
       }}
     >
-      {PORTAL_FRAME.map(([x, z], index) => (
-        <group key={index} position={[x * 0.72, 0, z * 0.72]}>
-          <mesh>
-            <boxGeometry args={[0.68, 0.28, 0.68]} />
-            <meshStandardMaterial color="#71875f" roughness={0.95} />
-          </mesh>
-          <mesh position={[0, 0.16, 0]}>
-            <boxGeometry args={[0.42, 0.05, 0.42]} />
-            <meshStandardMaterial color="#315c37" emissive="#14351d" emissiveIntensity={0.8} roughness={0.8} />
-          </mesh>
-        </group>
+      <VoxelField blocks={ring} />
+      {[
+        [-4, -4],
+        [-4, 4],
+        [4, -4],
+        [4, 4],
+      ].map(([x, z]) => (
+        <mesh key={`torch${x}${z}`} geometry={UNIT_BOX} position={[x, 3.2, z]} scale={0.4}>
+          <meshStandardMaterial color="#fff2c2" emissive="#fbbf24" emissiveIntensity={2.4} />
+        </mesh>
       ))}
-      <mesh rotation={[-Math.PI / 2, 0, 0]} position={[0, 0.16, 0]}>
-        <planeGeometry args={[2.05, 2.05]} />
-        <meshBasicMaterial color="#16051f" transparent opacity={0.94} />
+      <mesh rotation={[-Math.PI / 2, 0, 0]} position={[0, 1.05, 0]}>
+        <circleGeometry args={[3.6, 40]} />
+        <shaderMaterial vertexShader={PORTAL_VERTEX} fragmentShader={PORTAL_FRAGMENT} uniforms={uniforms} transparent side={THREE.DoubleSide} />
       </mesh>
-      <mesh rotation={[-Math.PI / 2, 0, 0]} position={[0, 0.18, 0]}>
-        <planeGeometry args={[1.82, 1.82]} />
-        <meshBasicMaterial color="#5b1172" transparent opacity={0.55} />
+      <mesh position={[0, 19, 0]} renderOrder={3} raycast={() => null}>
+        <cylinderGeometry args={[1.0, 1.7, 38, 20, 1, true]} />
+        <shaderMaterial
+          vertexShader={BEAM_VERTEX}
+          fragmentShader={BEAM_FRAGMENT}
+          uniforms={uniforms}
+          transparent
+          depthWrite={false}
+          side={THREE.DoubleSide}
+          blending={THREE.AdditiveBlending}
+        />
       </mesh>
-      <pointLight color="#a855f7" intensity={returning ? 20 : 4} distance={8} />
+      <pointLight position={[0, 3, 0]} color="#a855f7" intensity={returning ? 220 : 40} distance={30} decay={2} />
     </group>
   );
 }
 
+interface BoxProps {
+  readonly size: [number, number, number];
+  readonly position?: [number, number, number];
+  readonly rotation?: [number, number, number];
+  readonly material: THREE.Material;
+  readonly children?: React.ReactNode;
+}
+
+function Box({ size, position, rotation, material, children }: BoxProps) {
+  return (
+    <mesh geometry={UNIT_BOX} material={material} scale={size} position={position} rotation={rotation}>
+      {children}
+    </mesh>
+  );
+}
+
+function Dragon({ report }: { readonly report: THREE.Vector3 }) {
+  const root = useRef<THREE.Group>(null);
+  const neck = useRef<(THREE.Group | null)[]>([]);
+  const tail = useRef<(THREE.Group | null)[]>([]);
+  const wings = useRef<(THREE.Group | null)[]>([]);
+  const wingTips = useRef<(THREE.Group | null)[]>([]);
+  const jaw = useRef<THREE.Group>(null);
+
+  const materials = useMemo(() => {
+    const scales = new THREE.MeshStandardMaterial({ color: '#332b45', roughness: 0.8, emissive: '#22103a', emissiveIntensity: 0.45 });
+    const dark = new THREE.MeshStandardMaterial({ color: '#211b2e', roughness: 0.9, emissive: '#170a28', emissiveIntensity: 0.45 });
+    const membrane = new THREE.MeshStandardMaterial({
+      color: '#3b2e54',
+      roughness: 0.95,
+      side: THREE.DoubleSide,
+      emissive: '#2a1042',
+      emissiveIntensity: 0.5,
+    });
+    const eye = new THREE.MeshStandardMaterial({ color: '#2a0733', emissive: '#e879f9', emissiveIntensity: 4 });
+    return { scales, dark, membrane, eye };
+  }, []);
+
+  useEffect(() => {
+    const owned = Object.values(materials);
+    return () => owned.forEach((material) => material.dispose());
+  }, [materials]);
+
+  useFrame(({ clock }) => {
+    const time = clock.getElapsedTime();
+    const orbit = time * 0.16;
+    const group = root.current;
+    if (!group) return;
+
+    const x = Math.cos(orbit) * DRAGON_ORBIT;
+    const z = Math.sin(orbit) * DRAGON_ORBIT;
+    group.position.set(x, DRAGON_HEIGHT + Math.sin(time * 0.55) * 2.2, z);
+    group.rotation.y = Math.atan2(-Math.cos(orbit), -Math.sin(orbit));
+    group.rotation.z = -0.22 + Math.sin(time * 0.55) * 0.1;
+    group.rotation.x = Math.sin(time * 0.55 + Math.PI / 2) * 0.08;
+    report.copy(group.position);
+
+    const flap = Math.sin(time * 1.7);
+    wings.current.forEach((wing, index) => {
+      if (!wing) return;
+      wing.rotation.x = (index === 0 ? -1 : 1) * (0.15 + flap * 0.55);
+    });
+    wingTips.current.forEach((tip, index) => {
+      if (!tip) return;
+      tip.rotation.x = (index === 0 ? -1 : 1) * (0.2 + Math.sin(time * 1.7 - 0.55) * 0.45);
+    });
+    neck.current.forEach((segment, index) => {
+      if (!segment) return;
+      segment.rotation.y = Math.sin(time * 1.1 - index * 0.6) * 0.09;
+      segment.rotation.z = -0.16 + Math.sin(time * 0.9 - index * 0.5) * 0.05;
+    });
+    tail.current.forEach((segment, index) => {
+      if (!segment) return;
+      segment.rotation.y = Math.sin(time * 1.3 - index * 0.75) * 0.16;
+      segment.rotation.z = Math.sin(time * 0.8 - index * 0.4) * 0.05;
+    });
+    if (jaw.current) jaw.current.rotation.z = 0.18 + Math.sin(time * 0.7) * 0.16;
+  });
+
+  const { scales, dark, membrane, eye } = materials;
+
+  return (
+    <group ref={root} scale={0.55}>
+      <Box size={[6.4, 2.4, 2.8]} material={scales} />
+      <Box size={[4.6, 1.2, 3.4]} position={[-0.4, -0.6, 0]} material={dark} />
+      {[-2.4, -1.2, 0, 1.2, 2.4].map((offset) => (
+        <Box key={offset} size={[0.5, 0.9, 0.4]} position={[offset, 1.5, 0]} material={dark} />
+      ))}
+
+      <group ref={(el) => { neck.current[0] = el; }} position={[3, 0.6, 0]}>
+        <Box size={[2.2, 1.5, 1.5]} position={[1.1, 0, 0]} material={scales} />
+        <Box size={[0.4, 0.7, 0.35]} position={[1.1, 0.95, 0]} material={dark} />
+        <group ref={(el) => { neck.current[1] = el; }} position={[2.2, 0, 0]}>
+          <Box size={[2, 1.3, 1.3]} position={[1, 0, 0]} material={scales} />
+          <Box size={[0.4, 0.65, 0.35]} position={[1, 0.85, 0]} material={dark} />
+          <group ref={(el) => { neck.current[2] = el; }} position={[2, 0, 0]}>
+            <Box size={[1.8, 1.2, 1.2]} position={[0.9, 0, 0]} material={scales} />
+            <group position={[2.6, 0.1, 0]}>
+              <Box size={[2.4, 1.8, 2]} material={scales} />
+              <Box size={[1.3, 1, 1.4]} position={[1.7, -0.25, 0]} material={dark} />
+              <group ref={jaw} position={[0.9, -0.75, 0]}>
+                <Box size={[2, 0.45, 1.6]} position={[0.7, -0.2, 0]} material={dark} />
+              </group>
+              {[1, -1].map((side) => (
+                <Box key={side} size={[0.6, 0.35, 0.12]} position={[0.6, 0.35, side * 1.02]} material={eye} />
+              ))}
+              {[1, -1].map((side) => (
+                <Box key={`horn${side}`} size={[1.1, 0.4, 0.4]} position={[-0.5, 1, side * 0.6]} rotation={[0, 0, 0.25]} material={dark} />
+              ))}
+            </group>
+          </group>
+        </group>
+      </group>
+
+      {[1, -1].map((side, index) => (
+        <group key={side} ref={(el) => { wings.current[index] = el; }} position={[0.2, 0.9, side * 1.3]} rotation={[0, side * -0.22, 0]}>
+          <Box size={[1.6, 0.5, 4.6]} position={[0, 0, side * 2.3]} material={scales} />
+          <Box size={[4.4, 0.18, 4.4]} position={[-1.4, -0.1, side * 2.4]} material={membrane} />
+          <Box size={[4.6, 0.24, 0.24]} position={[-1.4, 0, side * 1.1]} material={dark} />
+          <Box size={[4, 0.24, 0.24]} position={[-1.6, 0, side * 3.4]} material={dark} />
+          <group ref={(el) => { wingTips.current[index] = el; }} position={[0, 0, side * 4.6]}>
+            <Box size={[1.2, 0.4, 4]} position={[-0.2, 0, side * 2]} material={scales} />
+            <Box size={[3.6, 0.16, 3.8]} position={[-1.9, -0.08, side * 2]} material={membrane} />
+            <Box size={[3.8, 0.2, 0.2]} position={[-1.8, 0, side * 3.6]} material={dark} />
+          </group>
+        </group>
+      ))}
+
+      <group ref={(el) => { tail.current[0] = el; }} position={[-3.2, 0.2, 0]}>
+        <Box size={[2.2, 1.6, 1.6]} position={[-1.1, 0, 0]} material={scales} />
+        <Box size={[0.4, 0.8, 0.35]} position={[-1.1, 1, 0]} material={dark} />
+        <group ref={(el) => { tail.current[1] = el; }} position={[-2.2, 0, 0]}>
+          <Box size={[2, 1.3, 1.3]} position={[-1, 0, 0]} material={scales} />
+          <Box size={[0.4, 0.7, 0.3]} position={[-1, 0.85, 0]} material={dark} />
+          <group ref={(el) => { tail.current[2] = el; }} position={[-2, 0, 0]}>
+            <Box size={[1.8, 1, 1]} position={[-0.9, 0, 0]} material={scales} />
+            <Box size={[0.35, 0.6, 0.28]} position={[-0.9, 0.7, 0]} material={dark} />
+            <group ref={(el) => { tail.current[3] = el; }} position={[-1.8, 0, 0]}>
+              <Box size={[1.6, 0.8, 0.8]} position={[-0.8, 0, 0]} material={dark} />
+              <group ref={(el) => { tail.current[4] = el; }} position={[-1.6, 0, 0]}>
+                <Box size={[1.4, 0.55, 0.55]} position={[-0.7, 0, 0]} material={dark} />
+                <Box size={[1, 0.9, 0.2]} position={[-1.4, 0.2, 0]} material={membrane} />
+              </group>
+            </group>
+          </group>
+        </group>
+      </group>
+
+      <pointLight position={[7, 0.4, 0]} color="#e879f9" intensity={12} distance={9} decay={2} />
+      <Sparkles count={26} scale={[9, 3, 4]} position={[-3, 0, 0]} size={4} speed={0.5} color="#e879f9" opacity={0.7} />
+    </group>
+  );
+}
+
+function CameraRig({ returning }: { readonly returning: boolean }) {
+  const { camera, pointer } = useThree();
+  const desired = useMemo(() => new THREE.Vector3(), []);
+  const focus = useMemo(() => new THREE.Vector3(), []);
+
+  useFrame(({ clock }, delta) => {
+    const time = clock.getElapsedTime();
+    if (returning) {
+      desired.set(0, 2, 0);
+      camera.position.lerp(desired, 1 - Math.exp(-delta * 1.8));
+      focus.set(0, 0, 0);
+      if (camera instanceof THREE.PerspectiveCamera) {
+        camera.fov += (105 - camera.fov) * delta * 1.6;
+        camera.updateProjectionMatrix();
+      }
+    } else {
+      const angle = 0.6 + time * 0.05 + pointer.x * 0.22;
+      const radius = 40 - pointer.y * 3;
+      desired.set(Math.cos(angle) * radius, 15 + pointer.y * 4 + Math.sin(time * 0.22) * 1.6, Math.sin(angle) * radius);
+      camera.position.lerp(desired, 1 - Math.exp(-delta * 2.2));
+      focus.set(pointer.x * 1.5, 5 + pointer.y * 1.2, 0);
+    }
+    camera.lookAt(focus);
+  });
+
+  return null;
+}
+
 function EndWorld({ onReturn }: { readonly onReturn: () => void }) {
   const [returning, setReturning] = useState(false);
+  const dragonPosition = useMemo(() => new THREE.Vector3(DRAGON_ORBIT, DRAGON_HEIGHT, 0), []);
 
   useEffect(() => {
     if (!returning) return;
-    const timer = window.setTimeout(onReturn, 1500);
+    const timer = window.setTimeout(onReturn, 1600);
     return () => window.clearTimeout(timer);
   }, [onReturn, returning]);
 
   return (
     <>
-      <color attach="background" args={['#08030f']} />
-      <fog attach="fog" args={['#08030f', 8, 46]} />
-      <ambientLight intensity={0.22} />
-      <directionalLight position={[5, 8, 6]} color="#d8b4fe" intensity={1.8} castShadow />
-      <pointLight position={[-4, 2, -5]} color="#7e22ce" intensity={15} distance={16} />
-      <CameraDrift returning={returning} />
-      <Sparkles count={120} scale={[28, 12, 38]} size={2} speed={0.35} color="#e9d5ff" opacity={0.85} />
-      <EndIsland position={[-5.4, -2.3, -8]} scale={2.4} />
-      <EndIsland position={[5.6, -1.4, -13]} scale={1.6} />
-      <EndIsland position={[0.2, -3.1, -20]} scale={3.3} />
-      <ObsidianPillar position={[-4.1, -2.5, -8.2]} height={5.2} crystal />
-      <ObsidianPillar position={[5.2, -1.7, -13]} height={3.8} crystal />
-      <ObsidianPillar position={[0.6, -3.2, -19]} height={6.8} />
-      <Dragon />
-      <ReturnPortal onActivate={() => setReturning(true)} returning={returning} />
+      <color attach="background" args={['#07030f']} />
+      <fog attach="fog" args={['#0b0618', 45, 175]} />
+      <ambientLight intensity={1.1} color="#b9a7e0" />
+      <hemisphereLight args={['#c4b5fd', '#2a1b3d', 1.2]} />
+      <directionalLight position={[14, 22, 10]} color="#efe6ff" intensity={2.2} />
+      <directionalLight position={[-16, 8, -12]} color="#7c3aed" intensity={1.6} />
+      <Stars radius={140} depth={70} count={1400} factor={5} saturation={0.7} fade speed={0.5} />
+      <Sparkles count={90} scale={[70, 34, 70]} position={[0, 8, 0]} size={3.5} speed={0.3} color="#e9d5ff" opacity={0.7} />
+      <CameraRig returning={returning} />
+      <Island layers={MAIN_ISLAND_LAYERS} seed={1} position={[0, 0, 0]} chorus />
+      <Island layers={FAR_ISLAND_LAYERS} seed={4} position={[-62, 10, -54]} scale={2.2} chorus />
+      <Island layers={FAR_ISLAND_LAYERS} seed={9} position={[70, -12, -30]} scale={1.8} />
+      <Island layers={FAR_ISLAND_LAYERS} seed={13} position={[18, 22, -92]} scale={3} chorus />
+      <Island layers={FAR_ISLAND_LAYERS} seed={21} position={[-40, -20, 62]} scale={2} />
+      {PILLARS.map((pillar) => (
+        <ObsidianPillar key={pillar.angle} {...pillar} dragon={dragonPosition} />
+      ))}
+      <ExitPortal onActivate={() => setReturning(true)} returning={returning} />
+      <Dragon report={dragonPosition} />
     </>
   );
 }
@@ -240,11 +559,11 @@ export default function EndWorldScene({ onReturn }: { readonly onReturn: () => v
   return (
     <Canvas
       aria-hidden
-      camera={{ fov: 55, position: [0, 1.8, 13] }}
-      className="absolute inset-0"
+      camera={{ fov: 52, position: [26, 11, 18], near: 0.1, far: 260 }}
+      // the canvas wrapper defaults to position: relative inline, which would push the overlay UI out of view
+      style={{ position: 'absolute', inset: 0 }}
       dpr={[1, 1.5]}
       gl={{ antialias: false, powerPreference: 'high-performance' }}
-      shadows
     >
       <EndWorld onReturn={onReturn} />
     </Canvas>


### PR DESCRIPTION
## What

The 3D End world behind the danger-zone easter egg was effectively invisible, so this rebuilds it.

Two reasons it did not show:

- `<Canvas>` sets `position: relative` inline, so `className="absolute inset-0"` never applied. The canvas stayed in flow at 900px tall and pushed the title and the **Return to the Overworld** button off screen (the button measured at `y=1716`).
- The flat CSS island/pillar layer painted on top of a scene that was dark and far away.

## Changes

- **`EndWorldScene.tsx`** rebuilt: instanced voxel End island with chorus plants, obsidian pillars with caged end crystals that beam at the dragon, exit portal with a bedrock frame, a shader star surface and a light column, an orbiting camera with pointer parallax, distant islands, and an ender dragon modelled after the in-game one (segmented neck and tail, flapping membrane wings with a trailing wingtip, jawed head with glowing eyes). Clicking the portal still returns.
- **`EndPortalEasterEgg.tsx`**: canvas positioned absolutely so the overlay UI stays on screen; the duplicated CSS island/pillar layer and star field are hidden while the 3D scene runs; the CSS dragon that crossed the screen now only renders on the fallback path.
- **`globals.css`**: `wing-flap` accepts `--flap-lo` / `--flap-hi` (defaults unchanged) so the shoulder and the wingtip can flap at different amplitudes.

The mobile and `prefers-reduced-motion` path is untouched and still uses the CSS scene, dragon included.

## Verification

`tsc`, `npm run lint` and `npm run build` all pass. Rendered in Chrome with no console errors, checked on both the desktop 3D path and the fallback.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a richer 3D End-world scene with voxel islands, plants, pillars, crystals, portal effects, stars, and sparkles.
  * Introduced a detailed animated dragon with articulated wings, swaying tail segments, and enhanced artwork.
  * Added interactive portal hover effects and an animated return transition.
  * Improved scene lighting, fog, camera framing, and visual depth.

* **Accessibility**
  * Disabled 3D End-world rendering when reduced motion is enabled.

* **Visual Improvements**
  * Added configurable wing-flap animation angles while retaining existing defaults.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->