### PR TITLE
fix(security): screen envVars against admin-only keys on create

### DIFF
--- a/backend/src/server-management/server-management.controller.ts
+++ b/backend/src/server-management/server-management.controller.ts
@@ -45,8 +45,8 @@ const ADMIN_ONLY_CONFIG_FIELDS = [
 ] as const;
 
 // Creation has no persisted config to compare against, so these are rejected
-// outright for non-admins. `envVars` is missing on purpose: the bundled Geyser
-// template ships one, and blocking it would break server creation from templates.
+// outright for non-admins. `envVars` is screened key by key in assertSafeEnvVars
+// instead, because the bundled Geyser template ships one.
 const ADMIN_ONLY_ON_CREATE_FIELDS = [
   'dockerImage',
   'dockerLabels',
@@ -59,6 +59,43 @@ const ADMIN_ONLY_ON_CREATE_FIELDS = [
   'purpurDownloadUrl',
   'foliaDownloadUrl',
 ] as const;
+
+const ADMIN_ONLY_ENV_KEYS = new Set([
+  'UID',
+  'GID',
+  'EXEC_DIRECTLY',
+  'JVM_OPTS',
+  'JVM_XX_OPTS',
+  'JVM_DD_OPTS',
+  'CUSTOM_SERVER',
+  'SERVER_JAR',
+  'RCON_PASSWORD',
+]);
+
+const ADMIN_ONLY_ENV_KEY_SUFFIXES = ['_DOWNLOAD_URL', '_LAUNCHER_URL'];
+
+const ARTIFACT_ENV_KEYS = new Set(['PLUGINS', 'MODS', 'MODPACK', 'DATAPACKS', 'GENERIC_PACKS']);
+
+const TRUSTED_ARTIFACT_HOSTS = new Set([
+  'download.geysermc.org',
+  'api.papermc.io',
+  'hangarcdn.papermc.io',
+  'cdn.modrinth.com',
+  'api.modrinth.com',
+  'mediafilez.forgecdn.net',
+  'edge.forgecdn.net',
+]);
+
+function isTrustedArtifactRef(value: string): boolean {
+  if (!/^[a-z][a-z0-9+.-]*:\/\//i.test(value)) return true;
+
+  try {
+    const url = new URL(value);
+    return url.protocol === 'https:' && TRUSTED_ARTIFACT_HOSTS.has(url.hostname.toLowerCase());
+  } catch {
+    return false;
+  }
+}
 
 function normalizeConfigValue(value: unknown): string {
   if (value === undefined || value === null) return '';
@@ -197,6 +234,34 @@ export class ServerManagementController {
     const provided = ADMIN_ONLY_ON_CREATE_FIELDS.filter((field) => normalizeConfigValue(config[field]));
     if (provided.length > 0) {
       throw new ForbiddenException(`Only admins can set these settings: ${provided.join(', ')}`);
+    }
+
+    this.assertSafeEnvVars(config.envVars);
+  }
+
+  private assertSafeEnvVars(envVars: string | undefined): void {
+    for (const entry of normalizeConfigValue(envVars).split('\n').filter(Boolean)) {
+      const separator = entry.indexOf('=');
+      if (separator === -1) continue;
+
+      const key = entry.slice(0, separator).trim().toUpperCase();
+      const value = entry.slice(separator + 1).trim();
+
+      if (ADMIN_ONLY_ENV_KEYS.has(key) || ADMIN_ONLY_ENV_KEY_SUFFIXES.some((suffix) => key.endsWith(suffix))) {
+        throw new ForbiddenException(`Only admins can set the ${key} environment variable`);
+      }
+
+      if (!ARTIFACT_ENV_KEYS.has(key)) continue;
+
+      const untrusted = value
+        .split(',')
+        .map((ref) => ref.trim())
+        .filter(Boolean)
+        .filter((ref) => !isTrustedArtifactRef(ref));
+
+      if (untrusted.length > 0) {
+        throw new ForbiddenException(`Only admins can load ${key} from an untrusted source: ${untrusted.join(', ')}`);
+      }
     }
   }
 


### PR DESCRIPTION
Follow-up to #186. That PR restricted the host-affecting **structured** fields on creation, but `envVars` was deliberately left out of `ADMIN_ONLY_ON_CREATE_FIELDS` so the bundled Geyser template (`PLUGINS=<geysermc url>`) would keep working.

`addCustomEnvVars` merges `envVars` over the environment derived from the structured config:

```ts
UID: config.uid,            // java-server.strategy.ts:95
GID: config.gid,            // :96
this.addCustomEnvVars(...)  // :109 -> Object.assign(env, customVars) at :367
```

Last write wins, so the same keys were reachable through `envVars` and bypassed the allowlist. A non-admin with `accessAllServers` could set `UID=0`, `GID=0`, `TYPE=PAPER` and `PAPER_DOWNLOAD_URL` / `PLUGINS` pointing anywhere, and get code execution as root inside the container.

## Change

`assertSafeEnvVars` screens `envVars` key by key on create, for non-admins only:

- Keys granting privilege or selecting which code runs (`UID`, `GID`, `JVM_OPTS`, `EXEC_DIRECTLY`, `CUSTOM_SERVER`, `SERVER_JAR`, `RCON_PASSWORD`, plus the `*_DOWNLOAD_URL` / `*_LAUNCHER_URL` suffixes) are admin-only.
- Artifact keys (`PLUGINS`, `MODS`, `MODPACK`, `DATAPACKS`, `GENERIC_PACKS`) stay available, but every URL must resolve to a known distribution host over https. Bare names are treated as container-local paths and left alone.

General-purpose file hosts are intentionally absent from `TRUSTED_ARTIFACT_HOSTS`: anyone can publish a jar there, which would reopen the hole.

The update path is unaffected — `envVars` was already in `ADMIN_ONLY_CONFIG_FIELDS`.

## Trade-off

`TRUSTED_ARTIFACT_HOSTS` needs maintenance. A non-admin using a legitimate CDN that is not listed gets a 403 and needs an admin to create the server. Preferred over a pure denylist, which is whack-a-mole across itzg's env surface.

## Verification

`npx jest` in `backend/` — 232/232 pass, including `should still allow template envVars and extraPorts`, so the Geyser template still creates. ESLint clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved server creation validation for environment variables and artifact references.
  - Restricted administrative settings and launcher/download URLs from non-administrative server configurations.
  - Added validation to ensure URL-based artifacts use HTTPS and approved hosts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->