### PR TITLE
fix(frontend): explain CurseForge API key setup in templates

### DIFF
--- a/frontend/src/app/dashboard/templates/page.tsx
+++ b/frontend/src/app/dashboard/templates/page.tsx
@@ -2,13 +2,13 @@
 
 import { useEffect, useState, useRef, useCallback } from "react";
 import Image from "next/image";
-import { Loader2, Package, AlertCircle, TrendingUp, Star } from "lucide-react";
+import { Loader2, Package, AlertCircle, Info, TrendingUp, Star } from "lucide-react";
 import { useLanguage } from "@/lib/hooks/useLanguage";
 import ModpackCard from "@/components/molecules/modpacks/ModpackCard";
 import { ModpackSearch } from "@/components/organisms/ModpackSearch";
 import { ModpackDetailsModalEnhanced } from "@/components/molecules/modpacks/ModpackDetailsModalEnhanced";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
-import { CurseForgeModpack, searchModpacks, getFeaturedModpacks, getPopularModpacks } from "@/services/curseforge/curseforge.service";
+import { CurseForgeModpack, searchModpacks, getFeaturedModpacks, getPopularModpacks, isCurseForgeApiKeyError } from "@/services/curseforge/curseforge.service";
 import { mcToast } from "@/lib/utils/minecraft-toast";
 
 export default function TemplatesPage() {
@@ -20,6 +20,7 @@ export default function TemplatesPage() {
   const [isLoadingMore, setIsLoadingMore] = useState(false);
   const [selectedModpack, setSelectedModpack] = useState<CurseForgeModpack | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const [needsApiKey, setNeedsApiKey] = useState(false);
   const [activeTab, setActiveTab] = useState("popular");
   const [pagination, setPagination] = useState({
     index: 0,
@@ -34,6 +35,7 @@ export default function TemplatesPage() {
   const loadInitialData = useCallback(async () => {
     setIsLoading(true);
     setError(null);
+    setNeedsApiKey(false);
 
     try {
       const [popularResponse, featuredResponse] = await Promise.all([getPopularModpacks(18), getFeaturedModpacks(12)]);
@@ -47,14 +49,13 @@ export default function TemplatesPage() {
       });
     } catch (err) {
       console.error("Error loading modpacks:", err);
-      const errorMessage = err instanceof Error ? err.message : "Unknown error";
 
-      if (errorMessage.includes("API key") || errorMessage.includes("403")) {
-        setError(t("curseforgeApiKeyNotConfigured"));
+      if (isCurseForgeApiKeyError(err)) {
+        setNeedsApiKey(true);
       } else {
         setError(t("errorLoadingModpacks"));
+        mcToast.error(t("errorLoadingModpacks"));
       }
-      mcToast.error(t("errorLoadingModpacks"));
     } finally {
       setIsLoading(false);
     }
@@ -163,6 +164,36 @@ export default function TemplatesPage() {
         </div>
       </div>
 
+      {needsApiKey && (
+        <div className="animate-fade-in">
+          <div className="mc-slot p-4 space-y-3" style={{ borderColor: "#f0b95a" }}>
+            <div className="flex items-start gap-3">
+              <Info className="h-5 w-5 text-amber-400 shrink-0 mt-0.5" />
+              <div className="text-sm">
+                <p className="font-minecraft text-amber-300 mb-1">{t("curseforgeApiKey")}</p>
+                <p className="text-gray-300">{t("curseforgeApiKeyNotConfigured")}</p>
+              </div>
+            </div>
+            <div className="space-y-2 sm:pl-8">
+              <p className="font-minecraft text-xs text-gray-200">{t("cfApiKeyHowTo")}</p>
+              <ol className="list-decimal list-inside space-y-1 text-xs text-gray-300">
+                <li>{t("cfApiKeyStep1")}</li>
+                <li>{t("cfApiKeyStep2")}</li>
+                <li>{t("cfApiKeyStep3")}</li>
+              </ol>
+              <div className="flex flex-wrap gap-4 pt-1 font-minecraft text-xs">
+                <a href="https://console.curseforge.com/" target="_blank" rel="noopener noreferrer" className="text-emerald-400 hover:underline">
+                  {t("getCurseforgeApiKey")}
+                </a>
+                <a href="/dashboard/settings/integrations" className="text-emerald-400 hover:underline">
+                  {t("goToSettings")}
+                </a>
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
+
       {error && (
         <div className="animate-fade-in">
           <div className="mc-slot flex items-start gap-3 p-4" style={{ borderColor: "#f05a5a" }}>
@@ -170,17 +201,12 @@ export default function TemplatesPage() {
             <div className="text-sm">
               <p className="font-minecraft text-red-300 mb-1">{t("error")}</p>
               <p className="text-gray-300">{error}</p>
-              {error === t("curseforgeApiKeyNotConfigured") && (
-                <a href="/dashboard/settings" className="block mt-2 text-emerald-400 hover:underline font-minecraft">
-                  {t("goToSettings")}
-                </a>
-              )}
             </div>
           </div>
         </div>
       )}
 
-      {!error && (
+      {!error && !needsApiKey && (
         <>
           <div className="animate-fade-in-up stagger-1">
             <ModpackSearch onSearch={handleSearch} isLoading={isSearching} />

--- a/frontend/src/lib/translations/de.ts
+++ b/frontend/src/lib/translations/de.ts
@@ -1404,6 +1404,11 @@ export const de: Record<TranslationKey, string> = {
   curseforgeApiKeyNotConfigured:
     'CurseForge API-Schlüssel ist nicht konfiguriert. Bitte fügen Sie ihn in den Einstellungen hinzu, um diese Funktion zu nutzen.',
   goToSettings: 'Zu Einstellungen gehen',
+  cfApiKeyHowTo: 'So bekommst du einen',
+  cfApiKeyStep1: 'Melde dich auf console.curseforge.com mit deinem CurseForge-Konto an.',
+  cfApiKeyStep2: 'Öffne den Bereich API Keys und kopiere den dort angezeigten Schlüssel.',
+  cfApiKeyStep3: 'Füge ihn unter Einstellungen > Integrationen > CurseForge API Key ein und speichere.',
+  getCurseforgeApiKey: 'API-Schlüssel holen',
   createServerFromModpack: 'Einen neuen Server mit diesem Modpack erstellen',
   serverIdRequired: 'Server-ID ist erforderlich',
   optional: 'optional',

--- a/frontend/src/lib/translations/en.ts
+++ b/frontend/src/lib/translations/en.ts
@@ -1383,6 +1383,11 @@ export const en = {
   curseforgeApiKeyNotConfigured:
     'CurseForge API Key is not configured. Please add it in Settings to use this feature.',
   goToSettings: 'Go to Settings',
+  cfApiKeyHowTo: 'How to get one',
+  cfApiKeyStep1: 'Sign in at console.curseforge.com with your CurseForge account.',
+  cfApiKeyStep2: 'Open the API Keys section and copy the key shown there.',
+  cfApiKeyStep3: 'Paste it in Settings > Integrations > CurseForge API Key and save.',
+  getCurseforgeApiKey: 'Get an API key',
   createServerFromModpack: 'Create a new server using this modpack',
   serverIdRequired: 'Server ID is required',
   optional: 'optional',

--- a/frontend/src/lib/translations/es.ts
+++ b/frontend/src/lib/translations/es.ts
@@ -1398,6 +1398,11 @@ export const es: Record<TranslationKey, string> = {
   curseforgeApiKeyNotConfigured:
     'La clave API de CurseForge no está configurada. Por favor agrégala en Configuración para usar esta función.',
   goToSettings: 'Ir a Configuración',
+  cfApiKeyHowTo: 'Cómo obtenerla',
+  cfApiKeyStep1: 'Inicia sesión en console.curseforge.com con tu cuenta de CurseForge.',
+  cfApiKeyStep2: 'Abre la sección API Keys y copia la clave que aparece ahí.',
+  cfApiKeyStep3: 'Pégala en Configuración > Integraciones > Clave API de CurseForge y guarda.',
+  getCurseforgeApiKey: 'Obtener una clave API',
   createServerFromModpack: 'Crear un nuevo servidor usando este modpack',
   serverIdRequired: 'El ID del servidor es requerido',
   optional: 'opcional',

--- a/frontend/src/lib/translations/fr.ts
+++ b/frontend/src/lib/translations/fr.ts
@@ -1385,6 +1385,11 @@ export const fr: Record<TranslationKey, string> = {
   curseforgeApiKeyNotConfigured:
     'La clé API CurseForge n’est pas configurée. Veuillez l’ajouter dans les paramètres pour utiliser cette fonctionnalité.',
   goToSettings: 'Aller aux paramètres',
+  cfApiKeyHowTo: 'Comment en obtenir une',
+  cfApiKeyStep1: 'Connectez-vous sur console.curseforge.com avec votre compte CurseForge.',
+  cfApiKeyStep2: 'Ouvrez la section API Keys et copiez la clé qui y est affichée.',
+  cfApiKeyStep3: 'Collez-la dans Paramètres > Intégrations > Clé API CurseForge et enregistrez.',
+  getCurseforgeApiKey: 'Obtenir une clé API',
   createServerFromModpack: 'Créer un nouveau serveur avec ce modpack',
   serverIdRequired: 'L’ID du serveur est requis',
   optional: 'optionnel',

--- a/frontend/src/lib/translations/nl.ts
+++ b/frontend/src/lib/translations/nl.ts
@@ -1412,6 +1412,11 @@ export const nl: Record<TranslationKey, string> = {
   curseforgeApiKeyNotConfigured:
     'CurseForge API Key is niet geconfigureerd. Voeg deze toe in Instellingen om deze functie te gebruiken.',
   goToSettings: 'Ga naar Instellingen',
+  cfApiKeyHowTo: 'Hoe krijg je er een',
+  cfApiKeyStep1: 'Log in op console.curseforge.com met je CurseForge-account.',
+  cfApiKeyStep2: 'Open het gedeelte API Keys en kopieer de sleutel die daar staat.',
+  cfApiKeyStep3: 'Plak hem in Instellingen > Integraties > CurseForge API Key en sla op.',
+  getCurseforgeApiKey: 'API-sleutel ophalen',
   createServerFromModpack: 'Maak een nieuwe server met dit modpack',
   serverIdRequired: 'Server ID is vereist',
   optional: 'optioneel',

--- a/frontend/src/lib/translations/pl.ts
+++ b/frontend/src/lib/translations/pl.ts
@@ -1385,6 +1385,11 @@ export const pl: Record<TranslationKey, string> = {
   curseforgeApiKeyNotConfigured:
     'Klucz API CurseForge nie jest Skonfigurowano. Dodaj to w Ustawieniach, aby korzystać z tej funkcji.',
   goToSettings: 'Przejdź do Ustawień',
+  cfApiKeyHowTo: 'Jak ją zdobyć',
+  cfApiKeyStep1: 'Zaloguj się na console.curseforge.com swoim kontem CurseForge.',
+  cfApiKeyStep2: 'Otwórz sekcję API Keys i skopiuj wyświetlony klucz.',
+  cfApiKeyStep3: 'Wklej go w Ustawienia > Integracje > Klucz API CurseForge i zapisz.',
+  getCurseforgeApiKey: 'Zdobądź klucz API',
   createServerFromModpack: 'Utwórz nowy serwer za pomocą tego modpacka',
   serverIdRequired: 'Identyfikator serwera jest wymagany',
   optional: 'opcjonalny',

--- a/frontend/src/lib/translations/pt.ts
+++ b/frontend/src/lib/translations/pt.ts
@@ -1398,6 +1398,11 @@ export const pt: Record<TranslationKey, string> = {
   curseforgeApiKeyNotConfigured:
     'A chave de API do CurseForge não está configurada. Adicione-a nas Configurações para usar esta função.',
   goToSettings: 'Ir para Configurações',
+  cfApiKeyHowTo: 'Como obter uma',
+  cfApiKeyStep1: 'Entre em console.curseforge.com com sua conta CurseForge.',
+  cfApiKeyStep2: 'Abra a seção API Keys e copie a chave exibida lá.',
+  cfApiKeyStep3: 'Cole em Configurações > Integrações > Chave API do CurseForge e salve.',
+  getCurseforgeApiKey: 'Obter uma chave API',
   createServerFromModpack: 'Criar um novo servidor usando este modpack',
   serverIdRequired: 'O ID do servidor é obrigatório',
   optional: 'opcional',

--- a/frontend/src/lib/translations/ru.ts
+++ b/frontend/src/lib/translations/ru.ts
@@ -1385,6 +1385,11 @@ export const ru: Record<TranslationKey, string> = {
   curseforgeApiKeyNotConfigured:
     'Ключ API CurseForge не настроен. Пожалуйста, добавьте его в Настройках, чтобы использовать эту функцию.',
   goToSettings: 'Перейти к Настройкам',
+  cfApiKeyHowTo: 'Как её получить',
+  cfApiKeyStep1: 'Войдите на console.curseforge.com с вашей учётной записью CurseForge.',
+  cfApiKeyStep2: 'Откройте раздел API Keys и скопируйте показанный там ключ.',
+  cfApiKeyStep3: 'Вставьте его в Настройки > Интеграции > Ключ API CurseForge и сохраните.',
+  getCurseforgeApiKey: 'Получить ключ API',
   createServerFromModpack: 'Создать новый сервер, используя этот модпак',
   serverIdRequired: 'Требуется ID сервера',
   optional: 'необязательно',

--- a/frontend/src/services/curseforge/curseforge.service.ts
+++ b/frontend/src/services/curseforge/curseforge.service.ts
@@ -1,3 +1,4 @@
+import axios from "axios";
 import api from "../axios.service";
 
 export interface CurseForgeAuthor {
@@ -115,6 +116,15 @@ export interface CurseForgeSearchResponse {
 export interface CurseForgeModResponse {
   data: CurseForgeModpack;
 }
+
+// The backend answers 400 when no CurseForge key is stored in settings and 403
+// when the stored key is rejected upstream. Both mean "fix your API key".
+export const isCurseForgeApiKeyError = (error: unknown): boolean => {
+  if (!axios.isAxiosError(error)) return false;
+  if (error.response?.status === 403) return true;
+  const message = (error.response?.data as { message?: string } | undefined)?.message ?? "";
+  return error.response?.status === 400 && message.toLowerCase().includes("api key");
+};
 
 export const searchModpacks = async (
   searchFilter?: string,


### PR DESCRIPTION
Closes the remaining half of #179.

## Problem

Opening **Templates** without a CurseForge API key stored in Settings shows a red "Error loading modpacks" panel and a matching toast. The backend is behaving correctly — `curseforge.controller.ts:19` answers `400 "CurseForge API key not configured. Please add it in settings."` — but the page never showed that message.

The detection read the wrong field:

```ts
const errorMessage = err instanceof Error ? err.message : "Unknown error";
if (errorMessage.includes("API key") || errorMessage.includes("403")) {
```

On an axios error `err.message` is `"Request failed with status code 400"`; the backend text is in `err.response.data.message`. So the branch never ran, and the "Go to Settings" link the page already had stayed hidden.

## Changes

- `curseforge.service.ts`: `isCurseForgeApiKeyError()` reads `response.status` and `response.data.message` (400 with no key stored, 403 when CurseForge rejects the stored key).
- `templates/page.tsx`: tracks the case in a `needsApiKey` flag instead of comparing translated strings. Renders an amber notice — same shape as the `importantInfo` block in the Mods tab — with three numbered steps for getting a key, a link to `console.curseforge.com` and a link straight to `/dashboard/settings/integrations` (it used to point at `/dashboard/settings`). No error toast for this case; the red panel stays for real failures.
- Five new keys across all eight dictionaries (`cfApiKeyHowTo`, `cfApiKeyStep1..3`, `getCurseforgeApiKey`).

## Notes

- Docs untouched: no endpoint or flow changed, and `doc/mods-plugins.md:292` already covers how to get a key.
- `frontend/AGENTS.md` lists seven dictionaries but `pt` is registered in `index.ts` too — worth fixing separately.
- `ModpackBrowser.tsx:33,50` swallows the same error and renders an empty dialog. Same root cause, left out of this PR.

## Testing

- `npx eslint src/...` clean on the touched files.
- `npx tsc --noEmit` clean (the pre-existing `.next/dev/types` complaint about `scene-preview/page.js` is unrelated).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added dedicated guidance when a CurseForge API key is missing or invalid.
  * Included step-by-step instructions and a link to obtain an API key.
  * Added localized setup guidance across supported languages.

* **Bug Fixes**
  * API-key configuration issues are now distinguished from general loading errors.
  * Prevented incomplete content from displaying while API-key setup is required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->