### PR TITLE
fix: graceful server shutdown and per-server backup RCON host

### DIFF
--- a/backend/src/docker-compose/docker-compose.service.ts
+++ b/backend/src/docker-compose/docker-compose.service.ts
@@ -5,7 +5,7 @@ import { promisify } from 'node:util';
 import * as fs from 'fs-extra';
 import * as yaml from 'js-yaml';
 import * as path from 'node:path';
-import { ServerConfig, ServerEdition, UpdateServerConfig } from 'src/server-management/dto/server-config.model';
+import { ServerConfig, ServerEdition, SHUTDOWN_BUFFER_SECONDS, UpdateServerConfig } from 'src/server-management/dto/server-config.model';
 import { ServerStrategyFactory } from 'src/server-management/strategies';
 
 const execAsync = promisify(exec);
@@ -997,6 +997,15 @@ export class DockerComposeService {
     return config.port;
   }
 
+  // Docker kills the container after this, so it must outlast the itzg stop announcement plus the final save
+  private resolveStopGracePeriod(config: ServerConfig, edition: ServerEdition): number {
+    if (edition !== 'JAVA') {
+      return SHUTDOWN_BUFFER_SECONDS;
+    }
+    const announceDelay = Number.parseInt(config.stopDelay ?? '', 10);
+    return (Number.isFinite(announceDelay) && announceDelay > 0 ? announceDelay : 0) + SHUTDOWN_BUFFER_SECONDS;
+  }
+
   private buildDockerComposeConfig(
     config: ServerConfig,
     environment: Record<string, string>,
@@ -1020,6 +1029,7 @@ export class DockerComposeService {
       environment,
       volumes,
       restart: config.restartPolicy,
+      stop_grace_period: `${this.resolveStopGracePeriod(config, edition)}s`,
     };
 
     // Only add resource limits for Java (Bedrock doesn't use JVM)

--- a/backend/src/docker-compose/docker-compose.service.ts
+++ b/backend/src/docker-compose/docker-compose.service.ts
@@ -1100,7 +1100,7 @@ export class DockerComposeService {
     return result;
   }
 
-  private buildBackupEnvironment(config: ServerConfig): Record<string, string> {
+  private buildBackupEnvironment(config: ServerConfig, useProxy: boolean): Record<string, string> {
     const strategy = ServerStrategyFactory.create(config.edition ?? 'JAVA');
 
     const env: Record<string, string> = {
@@ -1113,7 +1113,8 @@ export class DockerComposeService {
     };
 
     if (strategy.supportsRcon()) {
-      env.RCON_HOST = 'mc';
+      // On the shared proxy network every stack registers an "mc" alias, so target this server's own alias
+      env.RCON_HOST = useProxy ? config.id : 'mc';
       env.RCON_PORT = config.rconPort || '25575';
       if (config.rconPassword) env.RCON_PASSWORD = config.rconPassword;
       if (config.rconRetries) env.RCON_RETRIES = config.rconRetries;
@@ -1180,7 +1181,7 @@ export class DockerComposeService {
     serverDir: string,
     useProxy: boolean,
   ): Promise<void> {
-    const backupEnv = this.buildBackupEnvironment(config);
+    const backupEnv = this.buildBackupEnvironment(config, useProxy);
     this.addOptionalBackupEnv(backupEnv, config);
 
     const mcDataPath = path.join(this.BASE_DIR, 'servers', config.id, 'mc-data');

--- a/backend/src/server-management/dto/server-config.model.ts
+++ b/backend/src/server-management/dto/server-config.model.ts
@@ -3,6 +3,9 @@ import { PartialType } from '@nestjs/mapped-types';
 
 export type ServerEdition = 'JAVA' | 'BEDROCK';
 
+// Seconds Docker must keep waiting after the stop announcement so Minecraft can flush its final save
+export const SHUTDOWN_BUFFER_SECONDS = 60;
+
 export class ServerConfigDto {
   @IsString()
   @IsNotEmpty()

--- a/backend/src/server-management/server-management.service.ts
+++ b/backend/src/server-management/server-management.service.ts
@@ -10,13 +10,13 @@ import { Repository, Not, IsNull } from 'typeorm';
 import { Settings } from 'src/users/entities/settings.entity';
 import { DiscordService, ServerEventType, SupportedLanguage } from 'src/discord/discord.service';
 import { ConfigService } from '@nestjs/config';
-import { ServerEdition } from './dto/server-config.model';
+import { ServerEdition, SHUTDOWN_BUFFER_SECONDS } from './dto/server-config.model';
 import { AlertsService } from 'src/alerts/alerts.service';
 
 const execAsync = promisify(exec);
 
 const DOCKER_COMMANDS = {
-  COMPOSE_DOWN: 'docker compose down',
+  COMPOSE_DOWN: (timeout: number) => `docker compose down --timeout ${timeout}`,
   COMPOSE_UP: 'docker compose up -d',
   COMPOSE_PS_SERVICE: 'docker compose ps -aq mc',
   PS_FILTER: (serverId: string) => `docker ps -a --filter "name=^/${serverId}$" --format "{{.ID}}"`,
@@ -318,6 +318,44 @@ export class ServerManagementService {
 
   private async execComposeCommand(serverId: string, command: string) {
     return execAsync(command, this.getComposeExecOptions(serverId));
+  }
+
+  private parseComposeSeconds(value: unknown): number | undefined {
+    if (typeof value === 'number' && Number.isFinite(value) && value > 0) {
+      return value;
+    }
+    if (typeof value !== 'string') {
+      return undefined;
+    }
+    const match = /^(\d+)s?$/.exec(value.trim());
+    const seconds = match ? Number.parseInt(match[1], 10) : Number.NaN;
+    return Number.isFinite(seconds) && seconds > 0 ? seconds : undefined;
+  }
+
+  // Compose defaults to 10s, which SIGKILLs Minecraft mid-announcement and loses the final save
+  private async getStopTimeout(serverId: string): Promise<number> {
+    try {
+      const content = await fs.readFile(this.getDockerComposePath(serverId), 'utf-8');
+      const mc = (yaml.load(content) as any)?.services?.mc;
+
+      const grace = this.parseComposeSeconds(mc?.stop_grace_period);
+      if (grace !== undefined) {
+        return grace;
+      }
+
+      const announceDelay = this.parseComposeSeconds(mc?.environment?.STOP_SERVER_ANNOUNCE_DELAY);
+      if (announceDelay !== undefined) {
+        return announceDelay + SHUTDOWN_BUFFER_SECONDS;
+      }
+    } catch (error) {
+      this.logger.warn(`Could not read stop timeout for ${serverId}, using default`, error);
+    }
+
+    return SHUTDOWN_BUFFER_SECONDS;
+  }
+
+  private async execComposeDown(serverId: string) {
+    return this.execComposeCommand(serverId, DOCKER_COMMANDS.COMPOSE_DOWN(await this.getStopTimeout(serverId)));
   }
 
   private executeProcess(
@@ -703,7 +741,7 @@ export class ServerManagementService {
       }
 
       this.alertsService.markExpectedStop(serverId);
-      await this.execComposeCommand(serverId, DOCKER_COMMANDS.COMPOSE_DOWN);
+      await this.execComposeDown(serverId);
       await this.execComposeCommand(serverId, DOCKER_COMMANDS.COMPOSE_UP);
 
       this.logger.log(`Server ${serverId} restarted successfully`);
@@ -729,7 +767,7 @@ export class ServerManagementService {
 
       if (await fs.pathExists(dockerComposePath)) {
         this.alertsService.markExpectedStop(serverId);
-        await this.execComposeCommand(serverId, DOCKER_COMMANDS.COMPOSE_DOWN);
+        await this.execComposeDown(serverId);
       }
 
       if (await fs.pathExists(serverDataDir)) {
@@ -891,7 +929,7 @@ export class ServerManagementService {
       if (await fs.pathExists(dockerComposePath)) {
         try {
           this.alertsService.markExpectedStop(serverId);
-          await this.execComposeCommand(serverId, DOCKER_COMMANDS.COMPOSE_DOWN);
+          await this.execComposeDown(serverId);
         } catch (error) {
           this.logger.warn(`Could not stop server ${serverId} before deletion`, error);
         }
@@ -1456,7 +1494,7 @@ export class ServerManagementService {
       }
 
       if ((await this.getServerStatus(serverId)) !== 'not_found') {
-        await this.execComposeCommand(serverId, DOCKER_COMMANDS.COMPOSE_DOWN);
+        await this.execComposeDown(serverId);
       }
 
       await this.execComposeCommand(serverId, DOCKER_COMMANDS.COMPOSE_UP);
@@ -1524,7 +1562,7 @@ export class ServerManagementService {
       }
 
       this.alertsService.markExpectedStop(serverId);
-      await this.execComposeCommand(serverId, DOCKER_COMMANDS.COMPOSE_DOWN);
+      await this.execComposeDown(serverId);
 
       this.logger.log(`Server ${serverId} stopped successfully`);
       await this.sendDiscordNotification('stopped', serverId);

--- a/doc/administration.md
+++ b/doc/administration.md
@@ -451,6 +451,8 @@ services:
       - ./backups:/backups
 ```
 
+When the server runs behind the proxy, Minepanel sets `RCON_HOST` to the server ID instead of `mc`. All proxied stacks share `minepanel-network`, where every server also answers to the generic `mc` alias, so the backup would otherwise reach another server.
+
 ### Manual Backup
 
 From the Minepanel UI:


### PR DESCRIPTION
Two independent bugs, one commit each.

## `fix(server)`: wait for Minecraft final save before stopping — closes #192

`docker compose down` ran with Docker's default 10s grace period while the itzg image was still inside its `STOP_SERVER_ANNOUNCE_DELAY` (60s by default), so Minecraft got SIGKILLed before flushing its final save and worlds rolled back to the last autosave.

Two layers:

- The generated `mc` service now declares `stop_grace_period` (`stopDelay + 60s` for Java, `60s` for Bedrock).
- Every `compose down` passes an explicit `--timeout`, read from the server's own compose file. This covers servers that already exist, since their compose still carries `STOP_SERVER_ANNOUNCE_DELAY` even without `stop_grace_period`. A hand-tuned `stop_grace_period` wins over the derived value, so existing workarounds for slow modpacks are not overridden.

Wider than the issue reported: `COMPOSE_DOWN` is shared by stop, restart, start (down-before-up), clear data and delete. All five now go through `execComposeDown()`.

## `fix(backup)`: point backup RCON at the server's own alias — closes #193

Every proxied stack joins the shared `minepanel-network`, and Compose registers each `mc` service under the generic `mc` alias on top of the per-server alias. A backup container resolving `RCON_HOST=mc` could therefore reach a different server — auth retries when passwords differ, or backup commands landing on the wrong instance when they match.

`RCON_HOST` now uses the server ID when the stack is proxied, and stays `mc` when it is isolated. Side effect of the move to the shared proxy network, not of the backup code itself.

## Notes

- #193 needs the compose file regenerated to take effect (happens on next config save). There is no automatic migration.
- Build and the 232 backend tests pass.