### PR TITLE
feat(system): show the running version and flag newer releases

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -91,6 +91,8 @@ jobs:
         with:
           context: .
           push: true
+          build-args: |
+            APP_VERSION=${{ needs.changes.outputs.version }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
@@ -123,6 +125,8 @@ jobs:
         with:
           context: ./backend
           push: true
+          build-args: |
+            APP_VERSION=${{ needs.changes.outputs.version }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha

--- a/Dockerfile
+++ b/Dockerfile
@@ -39,6 +39,10 @@ RUN --mount=type=cache,target=/root/.npm \
     npm ci --omit=dev
 WORKDIR /app
 
+# Set by CI so the panel can tell which release it is running.
+ARG APP_VERSION=dev
+ENV APP_VERSION=$APP_VERSION
+
 RUN addgroup --system --gid 1001 nodejs && \
     adduser --system --uid 1001 nextjs
 

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -24,6 +24,10 @@ RUN --mount=type=cache,target=/root/.npm \
 
 COPY --from=builder /app/dist ./dist
 
+# Set by CI so the panel can tell which release it is running.
+ARG APP_VERSION=dev
+ENV APP_VERSION=$APP_VERSION
+
 EXPOSE 8091
 
 CMD ["npm", "run", "start:prod"]

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -10,6 +10,7 @@ import { ThrottlerModule, seconds } from '@nestjs/throttler';
 import config from 'src/config';
 import { DatabaseModule } from './database/database.module';
 import { SystemMonitoringModule } from './system-monitoring/system-monitoring.module';
+import { VersionModule } from './version/version.module';
 import { DiscordModule } from './discord/discord.module';
 import { CurseforgeModule } from './curseforge/curseforge.module';
 import { FilesModule } from './files/files.module';
@@ -35,6 +36,7 @@ import { JwtAuthGuard } from './auth/guards/auth.guard';
     ServerManagementModule,
     AuthModule,
     SystemMonitoringModule,
+    VersionModule,
     DiscordModule,
     CurseforgeModule,
     ModrinthModule,

--- a/backend/src/version/version.controller.ts
+++ b/backend/src/version/version.controller.ts
@@ -1,0 +1,14 @@
+import { Controller, Get, UseGuards } from '@nestjs/common';
+import { JwtAuthGuard } from '../auth/guards/auth.guard';
+import { VersionService } from './version.service';
+
+@Controller('version')
+@UseGuards(JwtAuthGuard)
+export class VersionController {
+  constructor(private readonly versionService: VersionService) {}
+
+  @Get()
+  async getVersion() {
+    return this.versionService.getVersionInfo();
+  }
+}

--- a/backend/src/version/version.module.ts
+++ b/backend/src/version/version.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { VersionController } from './version.controller';
+import { VersionService } from './version.service';
+
+@Module({
+  controllers: [VersionController],
+  providers: [VersionService],
+})
+export class VersionModule {}

--- a/backend/src/version/version.service.ts
+++ b/backend/src/version/version.service.ts
@@ -1,0 +1,84 @@
+import { Injectable, Logger } from '@nestjs/common';
+import axios from 'axios';
+
+export interface VersionInfo {
+  current: string | null;
+  latest: string | null;
+  updateAvailable: boolean;
+  releaseUrl: string | null;
+  publishedAt: string | null;
+}
+
+interface GithubRelease {
+  tag_name: string;
+  html_url: string;
+  published_at: string;
+}
+
+@Injectable()
+export class VersionService {
+  private readonly logger = new Logger(VersionService.name);
+  private readonly RELEASES_URL = 'https://api.github.com/repos/Ketbome/minepanel/releases/latest';
+  // GitHub allows 60 unauthenticated calls per hour and per IP, shared by every
+  // panel behind the same address, so the answer is held for an hour.
+  private readonly CACHE_TTL_MS = 60 * 60 * 1000;
+
+  private cache?: { release: GithubRelease | null; expiresAt: number };
+
+  async getVersionInfo(): Promise<VersionInfo> {
+    const current = this.getCurrentVersion();
+    const release = await this.getLatestRelease();
+    const latest = release ? release.tag_name.replace(/^v/, '') : null;
+
+    return {
+      current,
+      latest,
+      updateAvailable: this.isNewer(latest, current),
+      releaseUrl: release?.html_url ?? null,
+      publishedAt: release?.published_at ?? null,
+    };
+  }
+
+  // Injected at build time. A local run has no version, and comparing against a
+  // release would only produce a false update notice.
+  private getCurrentVersion(): string | null {
+    const version = (process.env.APP_VERSION ?? '').trim();
+    return version && version !== 'dev' ? version : null;
+  }
+
+  private async getLatestRelease(): Promise<GithubRelease | null> {
+    if (this.cache && this.cache.expiresAt > Date.now()) {
+      return this.cache.release;
+    }
+
+    try {
+      const response = await axios.get<GithubRelease>(this.RELEASES_URL, {
+        timeout: 5000,
+        headers: { Accept: 'application/vnd.github+json' },
+      });
+      this.cache = { release: response.data, expiresAt: Date.now() + this.CACHE_TTL_MS };
+    } catch (error) {
+      this.logger.warn(`Could not check for updates: ${error instanceof Error ? error.message : error}`);
+      // Cached as a miss too, so an unreachable GitHub is not retried on every request.
+      this.cache = { release: null, expiresAt: Date.now() + this.CACHE_TTL_MS };
+    }
+
+    return this.cache.release;
+  }
+
+  private isNewer(latest: string | null, current: string | null): boolean {
+    if (!latest || !current) return false;
+
+    const toParts = (value: string) => value.split('.').map((part) => Number.parseInt(part, 10) || 0);
+    const latestParts = toParts(latest);
+    const currentParts = toParts(current);
+
+    for (let index = 0; index < Math.max(latestParts.length, currentParts.length); index += 1) {
+      const left = latestParts[index] ?? 0;
+      const right = currentParts[index] ?? 0;
+      if (left !== right) return left > right;
+    }
+
+    return false;
+  }
+}

--- a/doc/administration.md
+++ b/doc/administration.md
@@ -520,6 +520,21 @@ docker compose up -d
 
 **Check for updates:**
 
+The sidebar shows the running version at the bottom. When a newer release exists, it turns
+into an amber **Update available** link pointing at that release's notes on GitHub.
+
+The version is baked into the image at build time, so a locally built image shows nothing.
+The panel asks the GitHub releases API at most once per hour and never fails a request over
+it: if GitHub is unreachable, the badge simply keeps showing the current version.
+
+`GET /version` returns the same data:
+
+```json
+{ "current": "1.11.33", "latest": "1.11.34", "updateAvailable": true, "releaseUrl": "...", "publishedAt": "..." }
+```
+
+From the shell:
+
 ```bash
 # Check current version
 docker images ketbom/minepanel
@@ -527,6 +542,24 @@ docker images ketbom/minepanel
 # Check latest version on Docker Hub
 https://hub.docker.com/r/ketbom/minepanel/tags
 ```
+
+**Updating automatically:**
+
+Minepanel does not update itself: it runs inside the stack it would have to recreate, and a
+failed self-update leaves the panel down with no way to roll back from the inside. Use
+[Watchtower](https://containrrr.dev/watchtower/) if you want it unattended:
+
+```yaml
+  watchtower:
+    image: containrrr/watchtower
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+    command: --interval 86400 --cleanup minepanel-backend minepanel-frontend
+    restart: unless-stopped
+```
+
+Pin the panel to a specific tag instead of `latest` if you would rather approve each update
+yourself.
 
 ### Update Minecraft Server
 

--- a/doc/api.md
+++ b/doc/api.md
@@ -177,6 +177,8 @@ Host monitoring endpoints:
 
 - `GET /system/stats`
 - `GET /system/network`
+- `GET /version` — running version, newest release and whether an update is available; the
+  GitHub lookup is cached for an hour and never fails the request
 
 ### Mod Providers
 

--- a/frontend/src/components/molecules/VersionBadge.tsx
+++ b/frontend/src/components/molecules/VersionBadge.tsx
@@ -1,0 +1,57 @@
+'use client';
+
+import { FC, useEffect, useState } from 'react';
+import { ArrowUpCircle } from 'lucide-react';
+import { cn } from '@/lib/utils';
+import { useLanguage } from '@/lib/hooks/useLanguage';
+import { getVersionInfo, VersionInfo } from '@/services/version/version.service';
+
+interface VersionBadgeProps {
+  readonly isCollapsed?: boolean;
+}
+
+export const VersionBadge: FC<VersionBadgeProps> = ({ isCollapsed }) => {
+  const { t } = useLanguage();
+  const [info, setInfo] = useState<VersionInfo | null>(null);
+
+  useEffect(() => {
+    getVersionInfo()
+      .then(setInfo)
+      .catch(() => setInfo(null));
+  }, []);
+
+  // A local run has no version baked into the image, so there is nothing to show.
+  if (!info?.current) return null;
+
+  if (info.updateAvailable && info.releaseUrl) {
+    return (
+      <a
+        href={info.releaseUrl}
+        target="_blank"
+        rel="noopener noreferrer"
+        title={`${t('updateAvailable')}: v${info.latest}`}
+        className={cn(
+          'flex h-9 items-center gap-2 text-amber-300 transition-colors hover:bg-amber-500/10 hover:text-amber-200',
+          isCollapsed ? 'justify-center px-0' : 'px-3',
+        )}
+      >
+        <ArrowUpCircle size={16} className="shrink-0" />
+        <span className={cn('font-minecraft text-[11px] whitespace-nowrap', isCollapsed ? 'hidden' : 'block')}>
+          {t('updateAvailable')} · v{info.latest}
+        </span>
+      </a>
+    );
+  }
+
+  return (
+    <p
+      className={cn(
+        'flex h-9 items-center font-minecraft text-[11px] text-gray-600',
+        isCollapsed ? 'justify-center px-0' : 'px-3',
+      )}
+      title={`Minepanel v${info.current}`}
+    >
+      v{info.current}
+    </p>
+  );
+};

--- a/frontend/src/components/organisms/Sidebar.tsx
+++ b/frontend/src/components/organisms/Sidebar.tsx
@@ -23,6 +23,7 @@ import { useUIStore, useServerNavStore } from '@/lib/store';
 import { cn } from '@/lib/utils';
 import { getCurrentUser, User } from '@/services/users/users.service';
 import { SidebarServerNav } from './SidebarServerNav';
+import { VersionBadge } from '../molecules/VersionBadge';
 
 const GithubIcon = ({ size = 16 }: { size?: number }) => (
   <svg
@@ -303,6 +304,8 @@ export function Sidebar() {
                 </a>
               ))}
             </div>
+
+            <VersionBadge isCollapsed={isCollapsed} />
           </div>
         </>
       )}

--- a/frontend/src/lib/translations/de.ts
+++ b/frontend/src/lib/translations/de.ts
@@ -1231,6 +1231,7 @@ export const de: Record<TranslationKey, string> = {
   modVersionLatest: 'Neueste verfügbare',
   modVersionsEmpty: 'Keine Versionen für diese Minecraft-Version/Loader',
   modUpdateAvailable: 'Update verfügbar',
+  updateAvailable: 'Update verfügbar',
   modOptional: 'Optional',
   modOptionalHelp: 'itzg startet den Server weiter, wenn keine kompatible Version existiert, und lässt diese Mod aus der Versionsberechnung heraus',
   versionFromModrinthProjects: 'Version aus Mods',

--- a/frontend/src/lib/translations/en.ts
+++ b/frontend/src/lib/translations/en.ts
@@ -1216,6 +1216,7 @@ export const en = {
   modVersionLatest: 'Latest available',
   modVersionsEmpty: 'No versions for this Minecraft version/loader',
   modUpdateAvailable: 'Update available',
+  updateAvailable: 'Update available',
   modOptional: 'Optional',
   modOptionalHelp: 'itzg keeps the server starting when no compatible version exists, and leaves this mod out of the version calculation',
   versionFromModrinthProjects: 'Set version from mods',

--- a/frontend/src/lib/translations/es.ts
+++ b/frontend/src/lib/translations/es.ts
@@ -1381,6 +1381,7 @@ export const es: Record<TranslationKey, string> = {
   modVersionLatest: 'Última disponible',
   modVersionsEmpty: 'Sin versiones para esta versión/loader',
   modUpdateAvailable: 'Actualización disponible',
+  updateAvailable: 'Actualización disponible',
   modOptional: 'Opcional',
   modOptionalHelp: 'itzg sigue arrancando el servidor si no hay versión compatible, y deja este mod fuera del cálculo de versión',
   versionFromModrinthProjects: 'Versión según los mods',

--- a/frontend/src/lib/translations/fr.ts
+++ b/frontend/src/lib/translations/fr.ts
@@ -1218,6 +1218,7 @@ export const fr: Record<TranslationKey, string> = {
   modVersionLatest: 'Dernière disponible',
   modVersionsEmpty: 'Aucune version pour cette version/loader',
   modUpdateAvailable: 'Mise à jour disponible',
+  updateAvailable: 'Mise à jour disponible',
   modOptional: 'Optionnel',
   modOptionalHelp: "itzg continue de démarrer le serveur si aucune version compatible n'existe, et exclut ce mod du calcul de version",
   versionFromModrinthProjects: 'Version selon les mods',

--- a/frontend/src/lib/translations/nl.ts
+++ b/frontend/src/lib/translations/nl.ts
@@ -1396,6 +1396,7 @@ export const nl: Record<TranslationKey, string> = {
   modVersionLatest: 'Laatste beschikbare',
   modVersionsEmpty: 'Geen versies voor deze Minecraft-versie/loader',
   modUpdateAvailable: 'Update beschikbaar',
+  updateAvailable: 'Update beschikbaar',
   modOptional: 'Optioneel',
   modOptionalHelp: 'itzg blijft de server starten als er geen compatibele versie is, en laat deze mod buiten de versieberekening',
   versionFromModrinthProjects: 'Versie op basis van mods',

--- a/frontend/src/lib/translations/pl.ts
+++ b/frontend/src/lib/translations/pl.ts
@@ -1217,6 +1217,7 @@ export const pl: Record<TranslationKey, string> = {
   modVersionLatest: 'Najnowsza dostępna',
   modVersionsEmpty: 'Brak wersji dla tej wersji Minecraft/loadera',
   modUpdateAvailable: 'Dostępna aktualizacja',
+  updateAvailable: 'Dostępna aktualizacja',
   modOptional: 'Opcjonalny',
   modOptionalHelp: 'itzg nadal uruchamia serwer, gdy nie ma zgodnej wersji, i pomija ten mod w obliczaniu wersji',
   versionFromModrinthProjects: 'Wersja na podstawie modów',

--- a/frontend/src/lib/translations/pt.ts
+++ b/frontend/src/lib/translations/pt.ts
@@ -1381,6 +1381,7 @@ export const pt: Record<TranslationKey, string> = {
   modVersionLatest: 'Última disponível',
   modVersionsEmpty: 'Sem versões para esta versão/loader',
   modUpdateAvailable: 'Atualização disponível',
+  updateAvailable: 'Atualização disponível',
   modOptional: 'Opcional',
   modOptionalHelp: 'O itzg continua iniciando o servidor se não houver versão compatível, e deixa este mod fora do cálculo de versão',
   versionFromModrinthProjects: 'Versão a partir dos mods',

--- a/frontend/src/lib/translations/ru.ts
+++ b/frontend/src/lib/translations/ru.ts
@@ -1218,6 +1218,7 @@ export const ru: Record<TranslationKey, string> = {
   modVersionLatest: 'Последняя доступная',
   modVersionsEmpty: 'Нет версий для этой версии Minecraft/загрузчика',
   modUpdateAvailable: 'Доступно обновление',
+  updateAvailable: 'Доступно обновление',
   modOptional: 'Необязательный',
   modOptionalHelp: 'itzg продолжит запуск сервера, если совместимой версии нет, и исключит этот мод из расчёта версии',
   versionFromModrinthProjects: 'Версия по модам',

--- a/frontend/src/services/version/version.service.ts
+++ b/frontend/src/services/version/version.service.ts
@@ -1,0 +1,14 @@
+import api from "../axios.service";
+
+export interface VersionInfo {
+  current: string | null;
+  latest: string | null;
+  updateAvailable: boolean;
+  releaseUrl: string | null;
+  publishedAt: string | null;
+}
+
+export const getVersionInfo = async (): Promise<VersionInfo> => {
+  const response = await api.get<VersionInfo>("/version");
+  return response.data;
+};


### PR DESCRIPTION
The panel could not tell whether it was outdated: the image carries no version, and nothing exposed one.

## What lands

**The image knows its version.** CI already computes `1.11.N` per push to main and tags the release; that value is now passed as the `APP_VERSION` build arg into the all-in-one and backend images. A locally built image gets `dev`, which the endpoint reports as "no version" so a dev run never shows a false update notice.

**`GET /version`** returns the running version, the newest GitHub release, whether an update exists, the release URL and its date.

- The GitHub lookup is cached for an hour. Unauthenticated GitHub allows 60 calls per hour per IP, shared by every panel behind the same address.
- A failed or slow lookup (5 s timeout) is cached as a miss and logged as a warning. The endpoint never throws, so an unreachable GitHub cannot break the sidebar.
- Version comparison is a numeric part-by-part compare, so `1.11.9` vs `1.11.10` orders correctly.

**The sidebar shows it.** Bottom of the nav: the running version in gray, or an amber **Update available · vX.Y.Z** link to the release notes when there is a newer one. Collapses to just the icon along with the rest of the sidebar.

## What this deliberately does not do

Minepanel does not update itself. It runs inside the stack it would have to recreate, so it would have to kill itself mid-command through a helper container, guess the compose file location and project name, and would leave the panel down with no way to roll back from the inside if the new image were broken.

`doc/administration.md` documents the manual command, a Watchtower service for people who want it unattended, and pinning a tag for people who want to approve each update.

## Verification

- `npm run test --prefix backend` — 234 passed
- `npm run build --prefix backend`, `npm run lint --prefix frontend`, `tsc --noEmit`
- `updateAvailable` key added to all 8 dictionaries

The badge only appears once an image built by this workflow is running, since older images have no `APP_VERSION`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added version visibility in the sidebar, including the current release and a link when an update is available.
  - Added automatic release checks with graceful handling when update information is unavailable.
  - Added a system endpoint providing current and latest version details.
  - Added localized update notifications across supported languages.

- **Documentation**
  - Documented version checking, update links, API details, automated updates, and version pinning options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->