### PR TITLE
fix(config): resolve volume subpaths so named-volume mounts land on the real data

### DIFF
--- a/backend/AGENTS.md
+++ b/backend/AGENTS.md
@@ -93,6 +93,10 @@ Path and filesystem patterns (critical):
 - Sources are used verbatim. Docker Desktop rewrites bind sources (`/host_mnt/...` on macOS,
   `/run/desktop/mnt/host/...` on Windows) and the daemon resolves them back; reshaping them
   breaks that.
+- The one exception is the volume subpath, which `docker inspect .Mounts` does not report:
+  a mount with `volume: subpath:` still lists the volume root as its `Source`. `readOwnMounts`
+  reads `.HostConfig.Mounts` in the same inspect and copies `VolumeOptions.Subpath` onto the
+  mount so `resolveHostPath` can append it. Any new mount lookup must go through that helper.
 - Never mix `serversDir` with the host dirs; they are not interchangeable.
 - **`servers/<id>/server.json` is the source of truth for a server's config.**
   `docker-compose.yml` is generated output; never parse it to read config. Reads go

--- a/backend/src/config.spec.ts
+++ b/backend/src/config.spec.ts
@@ -9,6 +9,10 @@ describe('resolveHostPath', () => {
     Source: `/var/lib/docker/volumes/${name}/_data`,
     Destination: destination,
   });
+  const subpathVolume = (name: string, destination: string, subpath: string): DockerMount => ({
+    ...volume(name, destination),
+    Subpath: subpath,
+  });
 
   it('returns the bind source as the host path', () => {
     const mounts = [bind('/srv/minepanel/servers', '/app/servers'), bind('/srv/minepanel/data', '/app/data')];
@@ -28,6 +32,21 @@ describe('resolveHostPath', () => {
 
     expect(resolveHostPath(mounts, '/app/servers')).toBe('/var/lib/docker/volumes/minepanel_all/_data/servers');
     expect(resolveHostPath(mounts, '/app/data')).toBe('/var/lib/docker/volumes/minepanel_all/_data/data');
+  });
+
+  // `docker inspect .Mounts` reports the volume root as Source even when only a subpath is
+  // mounted, so without the subpath the router bind landed next to the real data.
+  it('appends the subpath a volume was mounted with', () => {
+    const mounts = [subpathVolume('minepanel_data', '/app/servers', 'servers'), subpathVolume('minepanel_data', '/app/data', 'data')];
+
+    expect(resolveHostPath(mounts, '/app/servers')).toBe('/var/lib/docker/volumes/minepanel_data/_data/servers');
+    expect(resolveHostPath(mounts, '/app/data')).toBe('/var/lib/docker/volumes/minepanel_data/_data/data');
+  });
+
+  it('appends the subpath before the remainder', () => {
+    expect(resolveHostPath([subpathVolume('minepanel_data', '/app', 'panel')], '/app/data')).toBe(
+      '/var/lib/docker/volumes/minepanel_data/_data/panel/data',
+    );
   });
 
   it('prefers the deepest mount containing the path', () => {

--- a/backend/src/config.ts
+++ b/backend/src/config.ts
@@ -8,6 +8,15 @@ export interface DockerMount {
   Source?: string;
   Destination?: string;
   Driver?: string;
+  // Not reported by `docker inspect .Mounts`: a volume mounted with a subpath still lists the
+  // volume root as its Source, so readOwnMounts copies it in from .HostConfig.Mounts.
+  Subpath?: string;
+}
+
+// The mount request that produced a .Mounts entry, matched back to it by Target.
+interface MountSpec {
+  Target?: string;
+  VolumeOptions?: { Subpath?: string };
 }
 
 // The generated server compose files and the chown helper run against the host Docker
@@ -15,24 +24,37 @@ export interface DockerMount {
 // own /app/servers and /app/data actually come from instead of trusting BASE_DIR, so a
 // misconfigured env var cannot send servers to the wrong folder.
 //
-// Each mount's own Source is read verbatim, with no arithmetic on it. That is what makes
-// named volumes work: there the source is /var/lib/docker/volumes/<name>/_data, which no
-// amount of deriving from BASE_DIR would ever produce. It also keeps whatever path shape
-// the platform reports (Docker Desktop rewrites binds to /host_mnt/... and /run/desktop/...)
-// intact, since the daemon is the one resolving it back.
+// Each mount's own Source is what gets read, with no arithmetic beyond the subpath the
+// daemon itself applied. That is what makes named volumes work: there the source is
+// /var/lib/docker/volumes/<name>/_data, which no amount of deriving from BASE_DIR would
+// ever produce. It also keeps whatever path shape the platform reports (Docker Desktop
+// rewrites binds to /host_mnt/... and /run/desktop/...) intact, since the daemon is the
+// one resolving it back.
 function readOwnMounts(): DockerMount[] {
   try {
     const containerId = process.env.HOSTNAME || os.hostname();
     // execFileSync, not execSync: HOSTNAME is whatever the container spec says, and there is
     // no reason to hand it to a shell to reinterpret.
-    const stdout = execFileSync('docker', ['inspect', containerId, '--format', '{{json .Mounts}}'], {
-      encoding: 'utf8',
-      stdio: ['ignore', 'pipe', 'ignore'],
-      timeout: 5000,
-    }).trim();
+    // .Mounts says what is mounted where; .HostConfig.Mounts is the request that produced it
+    // and the only place a volume subpath survives.
+    const stdout = execFileSync(
+      'docker',
+      ['inspect', containerId, '--format', '{"mounts":{{json .Mounts}},"spec":{{json .HostConfig.Mounts}}}'],
+      {
+        encoding: 'utf8',
+        stdio: ['ignore', 'pipe', 'ignore'],
+        timeout: 5000,
+      },
+    ).trim();
 
-    const parsed: unknown = JSON.parse(stdout || '[]');
-    return Array.isArray(parsed) ? (parsed as DockerMount[]) : [];
+    const parsed = JSON.parse(stdout || '{}') as { mounts?: unknown; spec?: unknown };
+    const mounts = Array.isArray(parsed.mounts) ? (parsed.mounts as DockerMount[]) : [];
+    const spec = Array.isArray(parsed.spec) ? (parsed.spec as MountSpec[]) : [];
+
+    return mounts.map((mount) => {
+      const subpath = spec.find((entry) => entry.Target === mount.Destination)?.VolumeOptions?.Subpath;
+      return subpath ? { ...mount, Subpath: subpath } : mount;
+    });
   } catch {
     // Docker unavailable (e.g. local dev outside Docker) -> fall back to BASE_DIR.
     return [];
@@ -64,8 +86,12 @@ export function resolveHostPath(mounts: DockerMount[], containerPath: string): s
     return undefined;
   }
 
+  // With a subpath the container sees <Source>/<Subpath> at the destination, while Source
+  // alone points at the volume root. Handing the daemon that root makes it create the
+  // directory the compose file asks for, empty, next to the real data.
+  const source = mount.Subpath ? path.join(mount.Source, mount.Subpath) : mount.Source;
   const remainder = containerPath.slice(mount.Destination!.replace(/\/+$/, '').length);
-  return path.join(mount.Source, remainder);
+  return path.join(source, remainder);
 }
 
 // Container paths we are running in Docker but could not resolve to a host path. The

--- a/doc/storage-scaling.md
+++ b/doc/storage-scaling.md
@@ -29,8 +29,10 @@ Two path concepts drive the whole model (`backend/src/config.ts`):
   Each is auto-detected from the `Source` of the panel's own mount for that destination via
   `docker inspect` (`backend/src/config.ts`), falling back to `${BASE_DIR}/servers` and
   `${BASE_DIR}/data`. The source is used verbatim, which is what makes **named volumes** work:
-  there it is `/var/lib/docker/volumes/<name>/_data`. It works unchanged on a network
-  filesystem too, since `docker inspect` reports the host-side mountpoint path.
+  there it is `/var/lib/docker/volumes/<name>/_data`. If the volume was mounted with a
+  `subpath`, that is appended too — `docker inspect` reports only the volume root. It works
+  unchanged on a network filesystem too, since `docker inspect` reports the host-side
+  mountpoint path.
 - `backupBaseDir` (`BACKUP_BASE_DIR`, optional) — host path for backups, letting them live outside `${BASE_DIR}` (e.g. a NAS). A per-server `backupHostDir` override takes precedence. Empty falls back to `<serversHostDir>/<id>/backups`.
 
 When a server is generated, `./` volume entries are expanded to absolute host paths under

--- a/doc/troubleshooting.md
+++ b/doc/troubleshooting.md
@@ -377,6 +377,11 @@ mount pointed at an empty directory Docker then created — servers came up blan
 could not read `routes.json`. If you ran a named-volume install on 1.12.0, check that your
 servers are reading the data you expect before starting them again.
 
+Mounting a **subpath** of a volume (`volume: subpath: data` in the long syntax) works from
+1.12.4. `docker inspect` reports the volume root as the mount source even then, so before that
+the panel wrote its files to `_data/<subpath>/...` while the generated mounts pointed at
+`_data/...` — mc-router found an empty `proxy/` folder next to the real one and crash-looped.
+
 Volumes on a non-local driver (NFS, CIFS) cannot be resolved this way. The panel says so at
 startup and falls back to `BASE_DIR`; use a bind mount for those.
 :::


### PR DESCRIPTION
Closes #205.

## The bug

`docker inspect .Mounts` reports the **volume root** as a mount's `Source` even when only a
subpath of that volume is mounted. The subpath survives only in `.HostConfig.Mounts`, which
`readOwnMounts` was not reading:

```jsonc
// --mount type=volume,source=vol,target=/app/data,volume-subpath=data

// .Mounts  <- what config.ts read
{ "Destination": "/app/data", "Source": "/var/lib/docker/volumes/vol/_data" }

// .HostConfig.Mounts  <- where the subpath is
{ "Target": "/app/data", "VolumeOptions": { "Subpath": "data" } }
```

So on a subpath install the panel resolved `/app/data` to `_data`, while the kernel put its
actual writes in `_data/data`. Every generated bind pointed one level above the real data:

- mc-router got `_data/proxy`, a directory Docker created empty for it, and fataled on the
  missing `routes.json` — the crash loop in #205.
- Servers bind-mounted `_data/<id>/mc-data` instead of `_data/servers/<id>/mc-data`, same
  empty-directory failure, silently.

Same class of bug as the one #204 fixed (a host path that skips part of the real location), from
a different source: there it was arithmetic on the mount source, here it is a field the API does
not expose where you would look for it.

## The fix

`readOwnMounts` asks for both arrays in the same `docker inspect`, matches the spec back to the
mount by `Target`/`Destination`, and copies `VolumeOptions.Subpath` onto it. `resolveHostPath`
joins the subpath onto the source before appending the remainder.

Mounts without a subpath resolve byte-for-byte as before. Containers started with the short `-v`
syntax report `.HostConfig.Mounts` as `null`, which reads as no subpath.

## Verification

Against a live daemon (Docker 29.4), volume mounted at `/app/data` (subpath `data`) and
`/app/servers` (subpath `servers`):

```
/app/servers -> /var/lib/docker/volumes/<vol>/_data/servers
/app/data    -> /var/lib/docker/volumes/<vol>/_data/data
router bind  -> /var/lib/docker/volumes/<vol>/_data/data/proxy
```

That last path is where the reporter's `routes.json` already lives, so nothing has to be moved.

Two cases added to `config.spec.ts` (separate subpath mounts, and a subpath mount with a
remainder). Full backend suite: 400/400.

## Docs

- `doc/troubleshooting.md` — subpath mounts under the named-volume tip, with the symptom to
  recognise it by.
- `doc/storage-scaling.md` — the source is verbatim *except* for the subpath.
- `backend/AGENTS.md` — the subpath is the one exception to "sources are used verbatim"; mount
  lookups go through `resolveHostPath`.

The troubleshooting note says the fix landed in **1.12.4** — adjust if the next release is
numbered differently.
