### PR TITLE
fix(servers): replace server.json atomically instead of unlinking it first

### DIFF
--- a/backend/AGENTS.md
+++ b/backend/AGENTS.md
@@ -144,6 +144,12 @@ Path and filesystem patterns (critical):
   `ServerStoreService`. Import this module; never list them as providers again, or each
   module gets its own instance and the startup migration runs once per copy.
 - `src/docker-compose/server-store.service.ts` - `server.json` and the server index.
+  Both are written temp-then-`rename(2)`, with the temp file fsynced before the rename
+  and the directory fsynced after. Do not reach for `fs.move` here: with `overwrite` it
+  unlinks the destination first, leaving a window with no file at all. That matters more
+  than it looks for `server.json` — `readConfig` cannot tell an empty one from a server
+  that never had one, so the caller re-imports from the generated `docker-compose.yml`
+  and silently drops everything compose does not round-trip.
 - `src/proxy/proxy.service.ts` - proxy routes file path behavior.
 - `src/proxy/proxy-router.service.ts` - generates and runs the mc-router compose project.
 - `src/common/docker/host-context.service.ts` - reads the panel's own compose labels;

--- a/backend/src/docker-compose/server-store.service.spec.ts
+++ b/backend/src/docker-compose/server-store.service.spec.ts
@@ -82,6 +82,51 @@ describe('ServerStoreService', () => {
       const entries = await fs.readdir(path.join(serversDir, 'survival'));
       expect(entries.filter((name) => name.endsWith('.tmp'))).toEqual([]);
     });
+
+    it('refuses to write a config with no server id', async () => {
+      // Otherwise this lands in servers/undefined/ and reconciles back as a server.
+      await expect(service.writeConfig({} as ServerConfig)).rejects.toThrow('without a server id');
+      expect(await fs.pathExists(path.join(serversDir, 'undefined'))).toBe(false);
+    });
+
+    it('leaves the previous config intact when the new one cannot be serialised', async () => {
+      await service.writeConfig(config('survival', { maxPlayers: '20' }));
+
+      const circular = config('survival') as ServerConfig & { self?: unknown };
+      circular.self = circular;
+
+      await expect(service.writeConfig(circular)).rejects.toBeDefined();
+      // The failure mode to avoid is not a truncated file but a *missing* one:
+      // readConfig cannot tell that from a server that never had a config, so the
+      // caller would re-import from docker-compose.yml and lose the rest.
+      expect((await service.readConfig('survival'))?.maxPlayers).toBe('20');
+      const entries = await fs.readdir(path.join(serversDir, 'survival'));
+      expect(entries.filter((name) => name.endsWith('.tmp'))).toEqual([]);
+    });
+
+    it('never leaves the config missing while it is being replaced', async () => {
+      await service.writeConfig(config('survival', { maxPlayers: '20' }));
+      const configPath = service.getConfigPath('survival');
+
+      // fs-extra's move() with overwrite unlinks the destination before renaming,
+      // so the file genuinely disappears for a moment. Poll hard across a rewrite:
+      // with rename(2) the path is occupied the whole way through.
+      let sawMissing = false;
+      const poll = setInterval(() => {
+        if (!fs.pathExistsSync(configPath)) sawMissing = true;
+      }, 0);
+
+      try {
+        for (let i = 0; i < 40; i++) {
+          await service.writeConfig(config('survival', { maxPlayers: String(i) }));
+        }
+      } finally {
+        clearInterval(poll);
+      }
+
+      expect(sawMissing).toBe(false);
+      expect((await service.readConfig('survival'))?.maxPlayers).toBe('39');
+    });
   });
 
   describe('index', () => {

--- a/backend/src/docker-compose/server-store.service.ts
+++ b/backend/src/docker-compose/server-store.service.ts
@@ -42,6 +42,8 @@ export class ServerStoreService {
   // The panel is the only writer, but two requests can still race, so index
   // writes are serialised through this chain.
   private indexWrites: Promise<unknown> = Promise.resolve();
+  // Only to keep two temp files in the same directory apart.
+  private tempWrites = 0;
 
   constructor(private readonly configService: ConfigService) {
     this.SERVERS_DIR = this.configService.get('serversDir');
@@ -72,6 +74,11 @@ export class ServerStoreService {
   }
 
   async writeConfig(config: ServerConfig): Promise<void> {
+    // Without an id this lands in `servers/undefined/server.json`, where the next
+    // reconcile reads it back as a server called "undefined".
+    if (!config?.id) {
+      throw new Error(`Refusing to write ${CONFIG_FILE} without a server id`);
+    }
     await fs.ensureDir(path.join(this.SERVERS_DIR, config.id));
     await this.writeJsonAtomic(this.getConfigPath(config.id), this.stripDerived(config));
     await this.upsertIndexEntry(config);
@@ -175,16 +182,59 @@ export class ServerStoreService {
     return next;
   }
 
-  // Rename is atomic on the same filesystem, so a crash mid-write leaves the
-  // previous file rather than a truncated one.
+  /**
+   * Write to a temp file, then rename it over the target, so a reader never sees a
+   * half-written file and a crash leaves the previous contents rather than nothing.
+   *
+   * The details matter more here than they look. Losing a `server.json` is not a
+   * recoverable "file is missing": `readConfig` cannot tell an empty one from a
+   * server that never had one, so the caller re-imports from the generated
+   * `docker-compose.yml` and silently drops everything compose does not round-trip.
+   */
   private async writeJsonAtomic(target: string, data: unknown): Promise<void> {
-    const temp = `${target}.${process.pid}.tmp`;
+    // Serialise up front: a value that cannot be stringified has to fail before
+    // anything on disk has been touched.
+    const contents = `${JSON.stringify(data, null, 2)}\n`;
+    const temp = `${target}.${process.pid}.${++this.tempWrites}.tmp`;
+
     try {
-      await fs.writeJson(temp, data, { spaces: 2 });
-      await fs.move(temp, target, { overwrite: true });
+      const handle = await fs.open(temp, 'w');
+      try {
+        await fs.writeFile(handle, contents, 'utf8');
+        // The rename below can otherwise reach the disk before the bytes do,
+        // leaving a renamed but empty file after a power cut.
+        await fs.fsync(handle);
+      } finally {
+        await fs.close(handle);
+      }
+
+      // rename(2), not fs-extra's move(): move with overwrite unlinks the
+      // destination first (lib/move/move.js, `doRename`), which opens a window
+      // where the server has no config at all. rename replaces it in a single
+      // step, and is atomic on the same filesystem — which temp always is, being
+      // a sibling of the target.
+      await fs.rename(temp, target);
+      await this.fsyncDirectory(path.dirname(target));
     } catch (error) {
       await fs.remove(temp).catch(() => undefined);
       throw error;
+    }
+  }
+
+  // A rename only becomes durable once the directory entry itself is flushed.
+  private async fsyncDirectory(dir: string): Promise<void> {
+    try {
+      const handle = await fs.open(dir, 'r');
+      try {
+        await fs.fsync(handle);
+      } finally {
+        await fs.close(handle);
+      }
+    } catch (error) {
+      // Not supported on every platform or filesystem (Windows most notably). The
+      // rename stays atomic either way; only its durability across a power cut is
+      // weaker, so this is worth a log line and not an error.
+      this.logger.debug(`Could not fsync ${dir}: ${error.message}`);
     }
   }
 }


### PR DESCRIPTION
## Description

`writeJsonAtomic` in `ServerStoreService` isn't atomic in the way its comment claims. It ends with:

```js
await fs.move(temp, target, { overwrite: true });
```

fs-extra's `move` **unlinks the destination before renaming** (`node_modules/fs-extra/lib/move/move.js`, `doRename`):

```js
if (overwrite) {
  await remove(dest)      // server.json is gone here
}
await fs.rename(src, dest)
```

So a crash in that window leaves *no* `server.json` — the opposite of "a crash mid-write leaves the previous file rather than a truncated one".

That failure mode is worse than a truncated file. `readConfig` can't tell a missing `server.json` from a server that never had one, so the caller re-imports from the generated `docker-compose.yml` and silently drops every field compose doesn't round-trip, resetting the rest to whatever the compose file happened to encode. Since 1.12 made `server.json` the source of truth, that's the whole config.

## What changed

- **`rename(2)` instead of `fs.move`.** Replaces the file in one step, atomic on the same filesystem — which `temp` always is, being a sibling of the target.
- **fsync the temp file before the rename, and the directory after.** Without the first, the rename can reach disk before the bytes do and a power cut leaves a renamed but empty file. Without the second, the rename itself isn't durable. Directory fsync is best-effort and logs at debug where the platform doesn't support it (Windows); the rename stays atomic regardless.
- **`JSON.stringify` runs before anything on disk is touched**, so an unserialisable config fails without a write.
- **Unique temp names.** Two writes in the same directory previously picked the same `.<pid>.tmp` path.
- **Refuse to write a config with no `id`**, which previously landed in `servers/undefined/server.json` and reconciled back as a server named "undefined".

`servers.json` goes through the same helper, so it gets all of this too.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update
- [ ] 🔧 Configuration change
- [ ] ♻️ Refactoring (no functional changes)
- [ ] 🧪 Tests

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have tested my changes locally
- [x] I have updated documentation if needed
- [x] My changes don't introduce new warnings or errors

## Testing

Backend suite green (403). Four new cases in `server-store.service.spec.ts`, against a real temp directory rather than mocked `fs`:

- `never leaves the config missing while it is being replaced` — polls for the file disappearing across 40 rewrites. **Fails against the `fs.move` implementation and passes against `rename`**, so it pins the actual regression rather than just describing it.
- `leaves the previous config intact when the new one cannot be serialised`
- `refuses to write a config with no server id`
- plus the existing "leaves no temporary files behind"

## Notes

Found while writing #199, which stores per-server annotations in `server.json` and so made this load-bearing. Split out because it affects every config save, not just that feature — #199 now stacks on this branch.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved server configuration saving to prevent data loss if an update fails.
  * Existing configurations remain available while replacements are being saved.
  * Invalid configurations without a server ID are now rejected.
  * Failed saves clean up temporary data and preserve the last valid configuration.
  * Improved reliability when updating server and project configuration files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->