### PR TITLE
feat(mods): increase the MAX_RESOLVE_REFS for Curseforge and Modrinth services

### DIFF
--- a/backend/src/curseforge/curseforge.service.ts
+++ b/backend/src/curseforge/curseforge.service.ts
@@ -166,7 +166,7 @@ export class CurseforgeService {
   private readonly MINECRAFT_GAME_ID = 432;
   private readonly MODS_CLASS_ID = 6;
   private readonly MODPACK_CLASS_ID = 4471;
-  private readonly MAX_RESOLVE_REFS = 50;
+  private readonly MAX_RESOLVE_REFS = 500;
   private readonly CATEGORIES_TTL_MS = 24 * 60 * 60 * 1000;
 
   // 2 = Popularity, 3 = LastUpdated, 6 = TotalDownloads. CurseForge has no

--- a/backend/src/modrinth/modrinth.service.ts
+++ b/backend/src/modrinth/modrinth.service.ts
@@ -91,7 +91,7 @@ export class ModrinthService {
   private readonly apiClient: AxiosInstance;
   private readonly MODRINTH_API_BASE = 'https://api.modrinth.com/v2';
   private readonly KNOWN_LOADERS = ['forge', 'neoforge', 'fabric', 'quilt', 'datapack'];
-  private readonly MAX_RESOLVE_REFS = 50;
+  private readonly MAX_RESOLVE_REFS = 500;
   private readonly CATEGORIES_TTL_MS = 24 * 60 * 60 * 1000;
 
   private readonly SORT_INDEX: Record<ModSortField, string> = {


### PR DESCRIPTION

This change increases the maximum number of resolved mods which are returned to the frontend from 50 to 500. Currently, the Visual mode of the Mods listing will gracefully fail after the 50th entry, showing only the raw slug or project ID as the title and the raw version or version ID as the version.

This is necessary to fully support large custom mod lists, or unlinked versions of popular modpacks like Fabulously Optimized, Better MC, or All the Mods.

## Description

Change the private constant MAX_RESOLVE_REFS from 50 to 500 in the modrinth service and curseforge service.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update
- [ x ] 🔧 Configuration change
- [ ] ♻️ Refactoring (no functional changes)
- [ ] 🧪 Tests

## Checklist

- [ x ] My code follows the project's style guidelines
- [ x ] I have performed a self-review of my code
- [ x ] I have tested my changes locally
- [ x ] I have updated documentation if needed
- [ x ] My changes don't introduce new warnings or errors




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Increased the maximum number of project and version references that can be resolved in a single batch from 50 to 500.
  * Improved support for larger bulk operations across CurseForge and Modrinth.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->