### PR TITLE
fix(dashboard): show the proxy endpoint for proxy-routed servers

### DIFF
--- a/backend/src/proxy/proxy.controller.ts
+++ b/backend/src/proxy/proxy.controller.ts
@@ -24,6 +24,8 @@ export class ProxyController {
       available: !!settings.baseDomain,
       enabled: settings.enabled && !!settings.baseDomain,
       baseDomain: settings.baseDomain,
+      // The host port mc-router publishes: what players actually connect to.
+      proxyPort: router.proxyPort,
       autoScaleAvailable: router.autoScaleEnabled,
       // Whether the container is actually up, not whether a routes file exists.
       running,

--- a/frontend/src/app/dashboard/servers/page.tsx
+++ b/frontend/src/app/dashboard/servers/page.tsx
@@ -63,6 +63,7 @@ import { getTemplatesByEdition, ServerTemplate } from '@/lib/server-templates';
 import { ServerEdition } from '@/lib/types/types';
 import { TranslationKey } from '@/lib/translations';
 import { getCurrentUser } from '@/services/users/users.service';
+import { getProxyMappings, getProxyStatus } from '@/services/network.service';
 
 type ServerInfo = {
   id: string;
@@ -88,6 +89,7 @@ export default function Dashboard() {
   const [selectedTemplate, setSelectedTemplate] = useState<ServerTemplate | null>(null);
   const [selectedEdition, setSelectedEdition] = useState<ServerEdition>('JAVA');
   const [canCreateServers, setCanCreateServers] = useState(false);
+  const [proxyAddresses, setProxyAddresses] = useState<Record<string, string>>({});
   const availableTemplates = getTemplatesByEdition(selectedEdition);
 
   const form = useForm<{ id: string }>({
@@ -153,6 +155,24 @@ export default function Dashboard() {
     [t],
   );
 
+  // Proxied servers publish no host port, so the allocated one is not reachable:
+  // what players use is the router hostname.
+  const loadProxyAddresses = useCallback(async () => {
+    const status = await getProxyStatus();
+    if (!status.enabled) {
+      setProxyAddresses({});
+      return;
+    }
+
+    const mappings = await getProxyMappings();
+    const port = status.proxyPort && status.proxyPort !== '25565' ? `:${status.proxyPort}` : '';
+    setProxyAddresses(
+      Object.fromEntries(
+        mappings.map(({ host, backend }) => [backend.split(':')[0], `${host}${port}`]),
+      ),
+    );
+  }, []);
+
   const fetchServersFromBackend = useCallback(async () => {
     setIsLoading(true);
     try {
@@ -168,6 +188,7 @@ export default function Dashboard() {
       }));
 
       setServers(formattedServers);
+      await loadProxyAddresses();
       const updatedServers = await processServerStatuses(formattedServers);
       setServers(updatedServers);
     } catch (error) {
@@ -176,7 +197,7 @@ export default function Dashboard() {
     } finally {
       setIsLoading(false);
     }
-  }, [t, processServerStatuses]);
+  }, [t, processServerStatuses, loadProxyAddresses]);
 
   const refreshGlobalServers = useServersStore((state) => state.refreshAll);
 
@@ -605,9 +626,18 @@ export default function Dashboard() {
                       </div>
 
                       <div className="hidden md:block shrink-0 text-right leading-tight font-mono text-xs">
-                        <p className="text-gray-300" title={t('port')}>
-                          :{server.port}
-                        </p>
+                        {proxyAddresses[server.id] ? (
+                          <p
+                            className="text-gray-300 truncate max-w-40"
+                            title={t('serverConnection')}
+                          >
+                            {proxyAddresses[server.id]}
+                          </p>
+                        ) : (
+                          <p className="text-gray-300" title={t('port')}>
+                            :{server.port}
+                          </p>
+                        )}
                         <p className="text-gray-500 truncate max-w-40" title={t('container')}>
                           {server.containerName}
                         </p>

--- a/frontend/src/services/network.service.ts
+++ b/frontend/src/services/network.service.ts
@@ -74,6 +74,8 @@ export interface ProxyStatus {
   available: boolean;
   enabled: boolean;
   baseDomain: string | null;
+  /** Host port the mc-router container publishes. */
+  proxyPort?: string;
   autoScaleAvailable?: boolean;
   /** Whether the mc-router container is actually up. */
   running?: boolean;
@@ -88,6 +90,20 @@ export async function getProxyStatus(): Promise<ProxyStatus> {
     // `running` stays undefined: reporting false here would make the UI claim the
     // router is stopped when it just could not be reached.
     return { available: false, enabled: false, baseDomain: null, autoScaleAvailable: false };
+  }
+}
+
+export interface ProxyMapping {
+  host: string;
+  backend: string;
+}
+
+export async function getProxyMappings(): Promise<ProxyMapping[]> {
+  try {
+    const response = await api.get<ProxyMapping[]>('/proxy/mappings');
+    return response.data;
+  } catch {
+    return [];
   }
 }
 


### PR DESCRIPTION
Closes #211

## Problem

The dashboard server card shows the allocated backend port (`:25567`) for servers routed through mc-router. That port is not just "not the public one": when `useProxy` is on, `docker-compose.service.ts:1257` generates `expose` instead of `ports`, so the container publishes **no host port at all** and nobody can connect on it.

The server detail page (`ServerConnectionInfo`) already resolves the hostname correctly; `ServerQuickView` on the home page shows no port. The card was the only wrong spot.

## Change

- `backend/src/proxy/proxy.controller.ts` — `/proxy/status` now returns `proxyPort`, the host port mc-router publishes. It was already user-configurable, but the frontend could only read it from the admin-only settings endpoint.
- `frontend/src/services/network.service.ts` — `proxyPort` on `ProxyStatus`, plus `getProxyMappings()` over the existing `/proxy/mappings` endpoint (one request for every server instead of N calls to `/proxy/server/:id/hostname`).
- `frontend/src/app/dashboard/servers/page.tsx` — builds a `serverId → hostname` map from routes.json (mapping backends are `${id}:25565`) and renders the hostname when the server is routed, keeping `:port` when it is not. It refreshes with the server list, so creating, cloning or deleting a server updates it too.

A non-default router port renders as `hostname:port`; the default 25565 is omitted. Bedrock servers and those with `useProxy: false` are absent from routes.json, so they keep showing their host port.

## Verification

`npm run verify` passes (lint + typecheck + 424 backend tests).

No `doc/` change: the docs list the proxy endpoints without their response shapes and do not describe the card's contents.

https://claude.ai/code/session_01WQKPRQE5min4UZzynQpMpx