### PR TITLE
fix(updater): preserve host paths and verify backend health

### DIFF
--- a/backend/src/version/updater.service.spec.ts
+++ b/backend/src/version/updater.service.spec.ts
@@ -35,7 +35,7 @@ describe('UpdaterService', () => {
     // What `docker ps` reports for the running stack, i.e. the images a rollback
     // would go back to.
     execMock.mockImplementation((command: string) =>
-      command.startsWith('docker ps') ? 'backend ketbom/minepanel-backend:1.11.30\nfrontend ketbom/minepanel-frontend:1.11.30' : '',
+      command.startsWith('docker ps') ? 'backend sha256:backend-old\nfrontend sha256:frontend-old' : '',
     );
     hostContext = { get: jest.fn().mockResolvedValue(composeContext) } as never;
     config = { get: jest.fn().mockReturnValue('/opt/minepanel/data') } as never;
@@ -74,8 +74,9 @@ describe('UpdaterService', () => {
     it('mounts the host compose directory it was started from', async () => {
       await service.start();
 
-      expect(runCommand()).toContain(`-v '/opt/minepanel':/workspace`);
-      expect(runCommand()).toContain('-w /workspace');
+      expect(runCommand()).toContain(`-v '/opt/minepanel':'/opt/minepanel'`);
+      expect(runCommand()).toContain(`-w '/opt/minepanel'`);
+      expect(runCommand()).not.toContain('/workspace');
     });
 
     it('pulls and recreates the stack', async () => {
@@ -94,8 +95,8 @@ describe('UpdaterService', () => {
 
       await service.start();
 
-      expect(runCommand()).toContain('docker-compose.yml');
-      expect(runCommand()).toContain('override.yml');
+      expect(runCommand()).toContain('/opt/minepanel/docker-compose.yml');
+      expect(runCommand()).toContain('/opt/minepanel/override.yml');
     });
 
     // The daemon resolves this mount on the host: the panel's own /app/data
@@ -125,7 +126,10 @@ describe('UpdaterService', () => {
     it('waits for the panel to answer before calling it a success', async () => {
       await service.start();
 
-      expect(runCommand()).toContain('exec -T backend');
+      expect(runCommand()).toContain('exec -T backend node -e');
+      expect(runCommand()).toContain('/health');
+      expect(runCommand()).toContain('r.statusCode === 200');
+      expect(runCommand()).toContain('request.setTimeout(10000');
       expect(runCommand()).toContain('write_result succeeded');
     });
 
@@ -133,17 +137,18 @@ describe('UpdaterService', () => {
       await service.start();
 
       expect(runCommand()).toContain('write_result rolled-back');
-      expect(runCommand()).toContain('ketbom/minepanel-backend:1.11.30');
-      expect(runCommand()).toContain('ketbom/minepanel-frontend:1.11.30');
+      expect(runCommand()).toContain('sha256:backend-old');
+      expect(runCommand()).toContain('sha256:frontend-old');
     });
 
     it('records the images it started from so a rollback has somewhere to go', async () => {
       const result = await service.start();
 
       expect(result.fromDigests).toEqual({
-        backend: 'ketbom/minepanel-backend:1.11.30',
-        frontend: 'ketbom/minepanel-frontend:1.11.30',
+        backend: 'sha256:backend-old',
+        frontend: 'sha256:frontend-old',
       });
+      expect(execMock.mock.calls[0][0]).toContain('com.docker.compose.image');
     });
 
     it('records that an update is in flight so the panel can report it after restarting', async () => {

--- a/backend/src/version/updater.service.spec.ts
+++ b/backend/src/version/updater.service.spec.ts
@@ -52,11 +52,24 @@ describe('UpdaterService', () => {
 
       expect(await service.canSelfUpdate()).toBe(false);
     });
+
+    it('is false when the panel service cannot be identified', async () => {
+      hostContext.get.mockResolvedValue({ ...composeContext, service: undefined });
+
+      expect(await service.canSelfUpdate()).toBe(false);
+    });
   });
 
   describe('start', () => {
     it('refuses when there is no compose stack to act on', async () => {
       hostContext.get.mockResolvedValue({ configFiles: [] });
+
+      await expect(service.start()).rejects.toBeInstanceOf(UpdateNotSupportedError);
+      expect(execMock).not.toHaveBeenCalled();
+    });
+
+    it('refuses when the panel service cannot be identified', async () => {
+      hostContext.get.mockResolvedValue({ ...composeContext, service: undefined });
 
       await expect(service.start()).rejects.toBeInstanceOf(UpdateNotSupportedError);
       expect(execMock).not.toHaveBeenCalled();
@@ -74,7 +87,7 @@ describe('UpdaterService', () => {
     it('mounts the host compose directory it was started from', async () => {
       await service.start();
 
-      expect(runCommand()).toContain(`-v '/opt/minepanel':'/opt/minepanel'`);
+      expect(runCommand()).toContain(`--mount 'type=bind,src=/opt/minepanel,dst=/opt/minepanel'`);
       expect(runCommand()).toContain(`-w '/opt/minepanel'`);
       expect(runCommand()).not.toContain('/workspace');
     });
@@ -99,12 +112,25 @@ describe('UpdaterService', () => {
       expect(runCommand()).toContain('/opt/minepanel/override.yml');
     });
 
+    it('mounts compose files outside the working directory', async () => {
+      hostContext.get.mockResolvedValue({
+        ...composeContext,
+        configFiles: ['/opt/minepanel/docker-compose.yml', '/etc/minepanel/override.yml'],
+      });
+
+      await service.start();
+
+      expect(runCommand()).toContain(
+        `--mount 'type=bind,src=/etc/minepanel/override.yml,dst=/etc/minepanel/override.yml,readonly'`,
+      );
+    });
+
     // The daemon resolves this mount on the host: the panel's own /app/data
     // would send the outcome to a directory it cannot read back.
     it('writes the outcome to the host directory behind /app/data', async () => {
       await service.start();
 
-      expect(runCommand()).toContain(`-v '/opt/minepanel/data':/result`);
+      expect(runCommand()).toContain(`--mount 'type=bind,src=/opt/minepanel/data,dst=/result'`);
     });
 
     it('leaves an outcome behind when the updater dies before deciding', async () => {
@@ -129,7 +155,10 @@ describe('UpdaterService', () => {
       expect(runCommand()).toContain('exec -T backend node -e');
       expect(runCommand()).toContain('/health');
       expect(runCommand()).toContain('r.statusCode === 200');
-      expect(runCommand()).toContain('request.setTimeout(10000');
+      expect(runCommand()).toContain('AbortSignal.timeout(10000)');
+      expect(runCommand()).toContain('{ signal }');
+      expect(runCommand()).toContain(')).on(');
+      expect(runCommand()).toContain('error');
       expect(runCommand()).toContain('write_result succeeded');
     });
 

--- a/backend/src/version/updater.service.ts
+++ b/backend/src/version/updater.service.ts
@@ -80,12 +80,14 @@ export class UpdaterService {
     const command = [
       'docker run -d --rm',
       '-v /var/run/docker.sock:/var/run/docker.sock',
-      `-v ${this.shellQuote(context.workingDir)}:/workspace`,
+      // Compose records the paths visible to it in container labels. Preserve
+      // the host path so later updates can resolve the project directory.
+      `-v ${this.shellQuote(context.workingDir)}:${this.shellQuote(context.workingDir)}`,
       // The daemon resolves this path on the host, so the panel's own container
       // path would land the outcome in a directory the panel cannot read, and
       // the update would look stuck at "running" forever.
       `-v ${this.shellQuote(this.resultHostDir())}:/result`,
-      '-w /workspace',
+      `-w ${this.shellQuote(context.workingDir)}`,
       UPDATER_IMAGE,
       `sh -c ${this.shellQuote(script)}`,
     ].join(' ');
@@ -109,11 +111,11 @@ export class UpdaterService {
   }
 
   private buildScript(configFiles: string[], digests: Record<string, string>, startedAt: string, panelService?: string): string {
-    // Compose files are recorded as host paths; the working dir is mounted at
-    // /workspace, so only their basenames are needed inside the updater.
-    const fileArgs = configFiles.map((file) => `-f ${this.shellQuote(path.basename(file))}`).join(' ');
+    const fileArgs = configFiles.map((file) => `-f ${this.shellQuote(file)}`).join(' ');
     const compose = `docker compose ${fileArgs}`;
-    const health = panelService ? `${compose} exec -T ${panelService} true` : 'true';
+    const healthProbe =
+      "const request = require('http').get('http://localhost:8091' + (process.env.BASE_PATH || '') + '/health', (r) => process.exit(r.statusCode === 200 ? 0 : 1)); request.setTimeout(10000, () => request.destroy()); request.on('error', () => process.exit(1))";
+    const health = panelService ? `${compose} exec -T ${panelService} node -e ${this.shellQuote(healthProbe)}` : 'true';
     const rollback = Object.entries(digests)
       .map(([service, digest]) => `docker tag ${this.shellQuote(digest)} "$(${compose} config --images | grep -m1 ${this.shellQuote(service)})" || true`)
       .join('\n');
@@ -149,7 +151,7 @@ export class UpdaterService {
 
     try {
       const { stdout } = await execAsync(
-        `docker ps --filter "label=com.docker.compose.project=${project}" --format "{{.Label \\"com.docker.compose.service\\"}} {{.Image}}"`,
+        `docker ps --filter "label=com.docker.compose.project=${project}" --format "{{.Label \\"com.docker.compose.service\\"}} {{.Label \\"com.docker.compose.image\\"}}"`,
       );
 
       const digests: Record<string, string> = {};

--- a/backend/src/version/updater.service.ts
+++ b/backend/src/version/updater.service.ts
@@ -57,12 +57,12 @@ export class UpdaterService {
    */
   async canSelfUpdate(): Promise<boolean> {
     const context = await this.hostContext.get();
-    return !!context.workingDir && context.configFiles.length > 0;
+    return !!context.workingDir && context.configFiles.length > 0 && !!context.service;
   }
 
   async start(): Promise<UpdateResult> {
     const context = await this.hostContext.get();
-    if (!context.workingDir || context.configFiles.length === 0) {
+    if (!context.workingDir || context.configFiles.length === 0 || !context.service) {
       throw new UpdateNotSupportedError('The panel was not started by Docker Compose, so it cannot update itself');
     }
 
@@ -82,11 +82,12 @@ export class UpdaterService {
       '-v /var/run/docker.sock:/var/run/docker.sock',
       // Compose records the paths visible to it in container labels. Preserve
       // the host path so later updates can resolve the project directory.
-      `-v ${this.shellQuote(context.workingDir)}:${this.shellQuote(context.workingDir)}`,
+      `--mount ${this.shellQuote(`type=bind,src=${context.workingDir},dst=${context.workingDir}`)}`,
+      ...context.configFiles.map((file) => `--mount ${this.shellQuote(`type=bind,src=${file},dst=${file},readonly`)}`),
       // The daemon resolves this path on the host, so the panel's own container
       // path would land the outcome in a directory the panel cannot read, and
       // the update would look stuck at "running" forever.
-      `-v ${this.shellQuote(this.resultHostDir())}:/result`,
+      `--mount ${this.shellQuote(`type=bind,src=${this.resultHostDir()},dst=/result`)}`,
       `-w ${this.shellQuote(context.workingDir)}`,
       UPDATER_IMAGE,
       `sh -c ${this.shellQuote(script)}`,
@@ -110,12 +111,12 @@ export class UpdaterService {
     return path.dirname(RESULT_FILE);
   }
 
-  private buildScript(configFiles: string[], digests: Record<string, string>, startedAt: string, panelService?: string): string {
+  private buildScript(configFiles: string[], digests: Record<string, string>, startedAt: string, panelService: string): string {
     const fileArgs = configFiles.map((file) => `-f ${this.shellQuote(file)}`).join(' ');
     const compose = `docker compose ${fileArgs}`;
     const healthProbe =
-      "const request = require('http').get('http://localhost:8091' + (process.env.BASE_PATH || '') + '/health', (r) => process.exit(r.statusCode === 200 ? 0 : 1)); request.setTimeout(10000, () => request.destroy()); request.on('error', () => process.exit(1))";
-    const health = panelService ? `${compose} exec -T ${panelService} node -e ${this.shellQuote(healthProbe)}` : 'true';
+      "const signal = AbortSignal.timeout(10000); require('http').get('http://localhost:8091' + (process.env.BASE_PATH || '') + '/health', { signal }, (r) => process.exit(r.statusCode === 200 ? 0 : 1)).on('error', () => process.exit(1))";
+    const health = `${compose} exec -T ${panelService} node -e ${this.shellQuote(healthProbe)}`;
     const rollback = Object.entries(digests)
       .map(([service, digest]) => `docker tag ${this.shellQuote(digest)} "$(${compose} config --images | grep -m1 ${this.shellQuote(service)})" || true`)
       .join('\n');


### PR DESCRIPTION
## Summary

- preserve the host Compose working directory and absolute config paths during self-updates
- mount every Compose file with fail-safe bind mounts, including external overrides
- require the panel Compose service label before starting an update
- record immutable `com.docker.compose.image` IDs for rollback
- require an HTTP 200 from the backend `/health` endpoint with an end-to-end 10-second timeout
- add regression coverage for paths, prerequisites, rollback IDs, and health verification

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing

- `pnpm verify`
- 66 suites, 720 tests passed
- 95.32% line coverage

## Screenshots

Not applicable.

## Related Issues

None.

## Checklist

- [x] Tests pass locally
- [x] Code follows project conventions
- [x] No unrelated changes included
- [x] Documentation is unchanged because no public API or user flow changed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved rollback reliability by using image digests instead of image tags.
  * Fixed updater compose-file path handling when running from the host working directory.
  * Health checks now make a real request to the panel’s `/health` endpoint and validate the response.
  * Improved image version detection using container metadata for more accurate updates and rollbacks.
  * Prevented self-updates when the required compose service is unavailable.
  * Improved updater container mounting and configuration handling for safer, more reliable updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->