### PR TITLE
fix(users): restore nullable TypeORM queries on main

### DIFF
--- a/backend/src/auth/auth.service.tokens.spec.ts
+++ b/backend/src/auth/auth.service.tokens.spec.ts
@@ -1,5 +1,6 @@
 import { BadRequestException, InternalServerErrorException, ServiceUnavailableException } from '@nestjs/common';
 import { createHash } from 'node:crypto';
+import { IsNull } from 'typeorm';
 
 jest.mock('bcrypt', () => ({
   hash: jest.fn(async (value: string) => `hashed:${value}`),
@@ -112,7 +113,7 @@ describe('AuthService tokens, recovery and invitations', () => {
 
     await service.createPasswordReset('c@x.com');
 
-    expect(resetRepo.update).toHaveBeenCalledWith({ userId: 3, usedAt: null }, { usedAt: expect.any(Date) });
+    expect(resetRepo.update).toHaveBeenCalledWith({ userId: 3, usedAt: IsNull() }, { usedAt: expect.any(Date) });
     const saved = resetRepo.save.mock.calls[0][0];
     expect(saved.expiresAt.getTime() - Date.now()).toBeGreaterThan(29 * 60 * 1000);
     const [to, username, url] = authMail.sendPasswordResetEmail.mock.calls[0];

--- a/backend/src/auth/auth.service.tokens.spec.ts
+++ b/backend/src/auth/auth.service.tokens.spec.ts
@@ -146,6 +146,19 @@ describe('AuthService tokens, recovery and invitations', () => {
     expect(resetRepo.manager.save).not.toHaveBeenCalled();
   });
 
+  it('resetPassword consumes only unused tokens for the user', async () => {
+    resetRepo.findOne.mockResolvedValue({
+      userId: 3,
+      usedAt: null,
+      expiresAt: new Date(Date.now() + 10_000),
+      user: { id: 3, isActive: true, password: 'old' },
+    });
+
+    await service.resetPassword('t', 'newpass1');
+
+    expect(resetRepo.update).toHaveBeenCalledWith({ userId: 3, usedAt: IsNull() }, { usedAt: expect.any(Date) });
+  });
+
   it('manages invitations with audit entries', async () => {
     usersService.createInvitation.mockResolvedValue({ invitation: { id: 7, email: null, role: 'USER', permissions: {}, serverAccess: null, expiresAt: new Date() }, inviteUrl: 'u', token: 't' });
     const created = await service.createInvitation({}, { userId: 1, username: 'admin', role: 'ADMIN' }, true);

--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -2,7 +2,7 @@ import { BadRequestException, Injectable, InternalServerErrorException, Logger, 
 import { ConfigService } from '@nestjs/config';
 import { JwtService } from '@nestjs/jwt';
 import { InjectRepository } from '@nestjs/typeorm';
-import { LessThan, Repository } from 'typeorm';
+import { IsNull, LessThan, Repository } from 'typeorm';
 import * as bcrypt from 'bcrypt';
 import { createHash, randomBytes } from 'node:crypto';
 import { PayloadToken } from './models/token.model';
@@ -208,7 +208,7 @@ export class AuthService {
     const tokenHash = this.hashToken(rawToken);
     const expiresAt = new Date(Date.now() + this.getPasswordResetTtlMinutes() * 60 * 1000);
 
-    await this.passwordResetTokenRepo.update({ userId: user.id, usedAt: null }, { usedAt: new Date() });
+    await this.passwordResetTokenRepo.update({ userId: user.id, usedAt: IsNull() }, { usedAt: new Date() });
     await this.passwordResetTokenRepo.save({
       userId: user.id,
       tokenHash,
@@ -243,7 +243,7 @@ export class AuthService {
     await this.passwordResetTokenRepo.manager.save(passwordResetToken.user);
 
     const usedAt = new Date();
-    await this.passwordResetTokenRepo.update({ userId: passwordResetToken.userId, usedAt: null }, { usedAt });
+    await this.passwordResetTokenRepo.update({ userId: passwordResetToken.userId, usedAt: IsNull() }, { usedAt });
     await this.refreshTokenRepo.update({ userId: passwordResetToken.userId, revoked: false }, { revoked: true });
   }
 

--- a/backend/src/users/services/users.service.spec.ts
+++ b/backend/src/users/services/users.service.spec.ts
@@ -343,6 +343,10 @@ describe('UsersService', () => {
       const updated = await service.confirmEmailChange(1, ' 123456 ');
 
       expect(updated.email).toBe('new@example.com');
+      expect(pendingEmailRepo.findOne).toHaveBeenCalledWith({
+        where: { userId: 1, usedAt: IsNull() },
+        order: { createdAt: 'DESC' },
+      });
       expect(pendingEmailRepo.save).toHaveBeenCalledWith(expect.objectContaining({ id: 3, usedAt: expect.any(Date) }));
     });
   });
@@ -391,6 +395,10 @@ describe('UsersService', () => {
       const result = await service.getActiveInvitations();
 
       expect(result.map((i) => i.id)).toEqual([2]);
+      expect(invitationsRepo.find).toHaveBeenCalledWith({
+        where: { usedAt: IsNull() },
+        order: { createdAt: 'DESC' },
+      });
       expect(invitationsRepo.update).toHaveBeenCalledWith([1], { usedAt: expect.any(Date) });
     });
 
@@ -466,6 +474,7 @@ describe('UsersService', () => {
       const link = await service.getInvitationLink(4);
 
       expect(link).toMatch(/inviteToken=[a-f0-9]{64}$/);
+      expect(invitationsRepo.findOne).toHaveBeenCalledWith({ where: { id: 4, usedAt: IsNull() } });
       expect(invitation.tokenHash).not.toBe('old');
       expect(invitationsRepo.save).toHaveBeenCalledWith(invitation);
     });

--- a/backend/src/users/services/users.service.spec.ts
+++ b/backend/src/users/services/users.service.spec.ts
@@ -1,5 +1,6 @@
 import { BadRequestException, ConflictException, InternalServerErrorException, NotFoundException, UnauthorizedException } from '@nestjs/common';
 import { createHash } from 'node:crypto';
+import { IsNull } from 'typeorm';
 
 jest.mock('bcrypt', () => ({
   hash: jest.fn(async (value: string) => `hashed:${value}`),
@@ -313,7 +314,7 @@ describe('UsersService', () => {
       usersRepo.findOne.mockResolvedValueOnce(user()).mockResolvedValueOnce(null);
       const result = await service.requestEmailChange(1, { email: 'new@example.com' });
       expect(result).toEqual({ requiresConfirmation: true, pendingEmail: 'new@example.com' });
-      expect(pendingEmailRepo.update).toHaveBeenCalledWith({ userId: 1, usedAt: null }, { usedAt: expect.any(Date) });
+      expect(pendingEmailRepo.update).toHaveBeenCalledWith({ userId: 1, usedAt: IsNull() }, { usedAt: expect.any(Date) });
       expect(authMail.sendEmailChangeCodeEmail).toHaveBeenCalledWith('new@example.com', 'alice', expect.stringMatching(/^\d{6}$/));
     });
 

--- a/backend/src/users/services/users.service.ts
+++ b/backend/src/users/services/users.service.ts
@@ -1,6 +1,6 @@
 import { BadRequestException, ConflictException, Injectable, InternalServerErrorException, NotFoundException, UnauthorizedException } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository } from 'typeorm';
+import { IsNull, Repository } from 'typeorm';
 import { Users } from '../entities/users.entity';
 import { ChangePasswordDto, CreateUserInvitationDto, CreateUsersDto, UpdateProfileDto, UpdateUserAccessDto, UpdateUsersDto } from '../dtos/users.dto';
 import * as bcrypt from 'bcrypt';
@@ -317,7 +317,7 @@ export class UsersService {
       usedAt: null,
     });
 
-    await this.pendingEmailChangesRepo.update({ userId: user.id, usedAt: null }, { usedAt: new Date() });
+    await this.pendingEmailChangesRepo.update({ userId: user.id, usedAt: IsNull() }, { usedAt: new Date() });
     const savedChange = await this.pendingEmailChangesRepo.save(pendingChange);
 
     try {
@@ -335,7 +335,7 @@ export class UsersService {
 
   async confirmEmailChange(userId: number, code: string): Promise<Users> {
     const pendingChange = await this.pendingEmailChangesRepo.findOne({
-      where: { userId, usedAt: null },
+      where: { userId, usedAt: IsNull() },
       order: { createdAt: 'DESC' },
     });
 
@@ -378,7 +378,7 @@ export class UsersService {
   async getActiveInvitations(): Promise<UserInvitation[]> {
     const now = new Date();
     const invitations = await this.invitationsRepo.find({
-      where: { usedAt: null },
+      where: { usedAt: IsNull() },
       order: { createdAt: 'DESC' },
     });
 
@@ -462,7 +462,7 @@ export class UsersService {
   }
 
   async getInvitationLink(id: number): Promise<string> {
-    const invitation = await this.invitationsRepo.findOne({ where: { id, usedAt: null } });
+    const invitation = await this.invitationsRepo.findOne({ where: { id, usedAt: IsNull() } });
 
     if (!invitation || invitation.expiresAt < new Date()) {
       throw new NotFoundException('Invitation not found');


### PR DESCRIPTION
## Description

Restores the nullable TypeORM query fix from #227 onto `main`. The original PR targeted `chore/pnpm-security-coverage`, so the production release workflow correctly treated it as a non-main branch and never included it in a tagged release.

This branch is based on the current `main`, including #230.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] Documentation update
- [ ] Configuration change
- [ ] Refactoring (no functional changes)
- [x] Tests

## Checklist

- [x] My code follows the project style guidelines
- [x] I have performed a self-review of my code
- [x] I have tested my changes locally
- [x] I have updated documentation if needed
- [x] My changes do not introduce new warnings or errors

## Screenshots (if applicable)

Not applicable.

## Related Issues

Fixes #226
Restores #227 onto the correct base branch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of unused password-reset tokens.
  * Corrected processing of pending email changes and invitations when records have not yet been used.
  * Prevented previously consumed tokens from being selected during password resets.

* **Tests**
  * Added coverage verifying that only unused tokens and records are queried and updated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->