### PR TITLE
fix(system): read /system/network from instance settings

### DIFF
--- a/backend/src/system-monitoring/system-monitoring.module.ts
+++ b/backend/src/system-monitoring/system-monitoring.module.ts
@@ -1,11 +1,10 @@
 import { Module } from '@nestjs/common';
-import { TypeOrmModule } from '@nestjs/typeorm';
 import { SystemMonitoringController } from './system-monitoring.controller';
 import { SystemMonitoringService } from './system-monitoring.service';
-import { Settings } from 'src/users/entities/settings.entity';
+import { SettingsModule } from 'src/settings/settings.module';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Settings])],
+  imports: [SettingsModule],
   controllers: [SystemMonitoringController],
   providers: [SystemMonitoringService],
   exports: [SystemMonitoringService],

--- a/backend/src/system-monitoring/system-monitoring.service.spec.ts
+++ b/backend/src/system-monitoring/system-monitoring.service.spec.ts
@@ -12,13 +12,13 @@ const cpu = (idle: number, user: number) => ({ model: 'Test CPU', speed: 1, time
 
 describe('SystemMonitoringService', () => {
   let service: SystemMonitoringService;
-  let settingsRepo: { find: jest.Mock };
+  let instanceSettings: { getNetwork: jest.Mock };
 
   beforeEach(() => {
     jest.clearAllMocks();
     jest.spyOn(console, 'error').mockImplementation(() => {});
-    settingsRepo = { find: jest.fn().mockResolvedValue([]) };
-    service = new SystemMonitoringService({ get: jest.fn() } as any, settingsRepo as any);
+    instanceSettings = { getNetwork: jest.fn().mockResolvedValue({ publicIp: null, lanIp: null }) };
+    service = new SystemMonitoringService({ get: jest.fn() } as any, instanceSettings as any);
     jest.spyOn(os, 'totalmem').mockReturnValue(1000);
     jest.spyOn(os, 'freemem').mockReturnValue(250);
     jest.spyOn(os, 'uptime').mockReturnValue(42);
@@ -75,17 +75,17 @@ describe('SystemMonitoringService', () => {
     expect(service.formatBytes(5 * 1024 * 1024, -1)).toBe('5 MB');
   });
 
-  it('reads network settings from the first user and validates the LAN ip', async () => {
-    settingsRepo.find.mockResolvedValue([{ preferences: { publicIp: ' play.example.com ', lanIp: '192.168.1.10' } }]);
+  it('reads network settings from the instance settings and validates the LAN ip', async () => {
+    instanceSettings.getNetwork.mockResolvedValue({ publicIp: ' play.example.com ', lanIp: '192.168.1.10' });
     expect(await service.getNetworkInfo()).toEqual({ hostname: 'panel', localIPs: ['192.168.1.10'], publicIP: 'play.example.com' });
 
-    settingsRepo.find.mockResolvedValue([{ preferences: { publicIp: '  ', lanIp: '999.1.1' } }]);
+    instanceSettings.getNetwork.mockResolvedValue({ publicIp: '  ', lanIp: '999.1.1' });
     expect(await service.getNetworkInfo()).toEqual({ hostname: 'panel', localIPs: [], publicIP: null });
 
-    settingsRepo.find.mockResolvedValue([{ preferences: { lanIp: '10.0.0.999' } }]);
+    instanceSettings.getNetwork.mockResolvedValue({ publicIp: null, lanIp: '10.0.0.999' });
     expect((await service.getNetworkInfo()).localIPs).toEqual([]);
 
-    settingsRepo.find.mockRejectedValue(new Error('db'));
+    instanceSettings.getNetwork.mockRejectedValue(new Error('db'));
     expect(await service.getNetworkInfo()).toEqual({ hostname: 'panel', localIPs: [], publicIP: null });
   });
 });

--- a/backend/src/system-monitoring/system-monitoring.service.ts
+++ b/backend/src/system-monitoring/system-monitoring.service.ts
@@ -1,11 +1,9 @@
 import { Injectable } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
-import { InjectRepository } from '@nestjs/typeorm';
-import { Repository } from 'typeorm';
 import { exec } from 'node:child_process';
 import { promisify } from 'node:util';
 import * as os from 'node:os';
-import { Settings } from 'src/users/entities/settings.entity';
+import { InstanceSettingsService } from 'src/settings/instance-settings.service';
 
 const execAsync = promisify(exec);
 
@@ -37,8 +35,7 @@ export class SystemMonitoringService {
 
   constructor(
     private readonly configService: ConfigService,
-    @InjectRepository(Settings)
-    private readonly settingsRepo: Repository<Settings>,
+    private readonly instanceSettings: InstanceSettingsService,
   ) {}
 
   async getSystemStats(): Promise<SystemStats> {
@@ -208,15 +205,13 @@ export class SystemMonitoringService {
   async getNetworkInfo(): Promise<{ hostname: string; localIPs: string[]; publicIP: string | null }> {
     const localIPs: string[] = [];
 
-    // Get IPs from settings (first user's settings)
+    // Network config is instance-wide, not per user
     let publicIp: string | null = null;
     let lanIp: string | null = null;
     try {
-      const [settings] = await this.settingsRepo.find({ order: { id: 'ASC' }, take: 1 });
-      if (settings?.preferences) {
-        publicIp = settings.preferences.publicIp ?? null;
-        lanIp = settings.preferences.lanIp ?? null;
-      }
+      const network = await this.instanceSettings.getNetwork();
+      publicIp = network.publicIp;
+      lanIp = network.lanIp;
     } catch (error) {
       console.error('Error fetching network settings:', error);
     }


### PR DESCRIPTION
## Summary

`GET /system/network` still read `publicIp`/`lanIp` from the first user's `Settings.preferences`, but the Network settings page writes them through `InstanceSettingsService.setNetwork` since the instance-settings move — and the startup migration deletes the moved keys from user preferences. The endpoint therefore returned empty addresses even when network settings were configured.

## Changes

- `SystemMonitoringService.getNetworkInfo` now reads `InstanceSettingsService.getNetwork()` instead of the first user's settings row.
- `SystemMonitoringModule` imports `SettingsModule` and drops the `Settings` repository.
- Updated the service spec to mock `InstanceSettingsService` (trim + LAN IP validation behavior unchanged).

## Context

Prerequisite for #225: the compact server header's address menu reuses `/system/network`, so it needs the canonical instance values.

## Testing

- `pnpm verify` green (lint + typecheck + 721 backend tests, coverage 95%).

https://claude.ai/code/session_01HriKHdKAXb57HFnNf1yV82

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - System monitoring now retrieves public and LAN IP addresses from the instance-wide network configuration.
  - Network information remains accurate when settings are unavailable, including cases where either address is not configured.
  - Improved consistency of network details displayed by system monitoring across the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->