### PR TITLE
fix(docker): survive a stale HOSTNAME when detecting the panel's own container

### DIFF
--- a/backend/AGENTS.md
+++ b/backend/AGENTS.md
@@ -102,6 +102,15 @@ Path and filesystem patterns (critical):
   a mount with `volume: subpath:` still lists the volume root as its `Source`. `readOwnMounts`
   reads `.HostConfig.Mounts` in the same inspect and copies `VolumeOptions.Subpath` onto the
   mount so `resolveHostPath` can append it. Any new mount lookup must go through that helper.
+- The own container id comes from `common/docker/own-container.ts` (`ownContainerIds`):
+  `HOSTNAME` first, then the id in `/proc/self/mountinfo`. Watchtower recreates a container
+  with the old hostname, so `HOSTNAME` alone names a container that no longer exists. Never
+  call `docker inspect $HOSTNAME` directly; take the ids from that helper.
+- `readOwnMounts` returns `[]` outside a container (local dev, `BASE_DIR` is right) and
+  `undefined` inside one it could not inspect. The latter puts both `/app/servers` and
+  `/app/data` in `unresolvedHostPaths`; `ServerManagementService.startServer`/`restartServer`
+  and `ProxyRouterService.start` refuse to run against those. Any new code that writes a host
+  path into a bind mount must check `unresolvedHostPaths` the same way.
 - Never mix `serversDir` with the host dirs; they are not interchangeable.
 - **`servers/<id>/server.json` is the source of truth for a server's config.**
   `docker-compose.yml` is generated output; never parse it to read config. Reads go

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,5 +1,8 @@
 # Build context is the repo root (pnpm workspace): docker build -f backend/Dockerfile .
-FROM node:22-alpine AS builder
+# The builder runs on the build host's own architecture: nothing in it is target-specific
+# (bcrypt ships prebuilds for every platform and picks one at runtime), and running node
+# under QEMU for the arm64 image has crashed with SIGILL and hung a release build for hours.
+FROM --platform=$BUILDPLATFORM node:22-alpine AS builder
 
 ENV HUSKY=0 CI=true
 RUN corepack enable

--- a/backend/src/common/docker/host-context.service.spec.ts
+++ b/backend/src/common/docker/host-context.service.spec.ts
@@ -1,4 +1,5 @@
 import { HostContextService } from './host-context.service';
+import * as ownContainer from './own-container';
 
 const execMock = jest.fn();
 jest.mock('node:child_process', () => ({
@@ -19,6 +20,7 @@ describe('HostContextService', () => {
   const labels = (value: Record<string, string>) => JSON.stringify(value);
 
   beforeEach(() => {
+    jest.restoreAllMocks();
     jest.clearAllMocks();
     process.env.HOSTNAME = 'abc123def';
     service = new HostContextService();
@@ -66,6 +68,16 @@ describe('HostContextService', () => {
     await service.get();
 
     expect(execMock).toHaveBeenCalledTimes(1);
+  });
+
+  // Watchtower recreates the container with the old hostname, so the first id is
+  // a container that no longer exists and only the mountinfo id answers.
+  it('falls through to the next id when HOSTNAME names a container that is gone', async () => {
+    jest.spyOn(ownContainer, 'ownContainerIds').mockReturnValue(['stale000', 'f'.repeat(64)]);
+    execMock.mockImplementation((command: string) => (command.includes('stale000') ? new Error('No such object: stale000') : labels({ 'com.docker.compose.service': 'backend' })));
+
+    expect((await service.get()).service).toBe('backend');
+    expect(execMock).toHaveBeenCalledTimes(2);
   });
 
   it('returns an empty context instead of throwing when docker inspect fails', async () => {

--- a/backend/src/common/docker/host-context.service.ts
+++ b/backend/src/common/docker/host-context.service.ts
@@ -1,6 +1,7 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { exec } from 'node:child_process';
 import { promisify } from 'node:util';
+import { ownContainerIds } from './own-container';
 
 const execAsync = promisify(exec);
 
@@ -35,30 +36,33 @@ export class HostContextService {
   }
 
   private async inspectSelf(): Promise<HostContext> {
-    // Docker sets HOSTNAME to the short container id unless the compose file
-    // overrides it, which none of the shipped ones do.
-    const containerId = process.env.HOSTNAME?.trim();
-    if (!containerId) {
+    // HOSTNAME first, then the id mountinfo reports, which is the one that still
+    // works after a tool such as Watchtower recreated the container with the old
+    // hostname. Both are ids Docker generated, never something a shell could reinterpret.
+    const ids = ownContainerIds();
+    if (ids.length === 0) {
       this.logger.warn('No container id in HOSTNAME; the panel is probably not running in Docker');
       return { configFiles: [] };
     }
 
-    try {
-      const format = '{{json .Config.Labels}}';
-      const { stdout } = await execAsync(`docker inspect --format '${format}' ${containerId}`);
-      const labels = JSON.parse(stdout.trim() || '{}') as Record<string, string>;
+    for (const containerId of ids) {
+      try {
+        const format = '{{json .Config.Labels}}';
+        const { stdout } = await execAsync(`docker inspect --format '${format}' ${containerId}`);
+        const labels = JSON.parse(stdout.trim() || '{}') as Record<string, string>;
 
-      return {
-        project: labels['com.docker.compose.project'] || undefined,
-        workingDir: labels['com.docker.compose.project.working_dir'] || undefined,
-        configFiles: this.parseConfigFiles(labels['com.docker.compose.project.config_files']),
-        service: labels['com.docker.compose.service'] || undefined,
-      };
-    } catch (error) {
-      // Not fatal: callers fall back to their own defaults and say so.
-      this.logger.warn(`Could not inspect the panel's own container (${containerId})`, error);
-      return { configFiles: [] };
+        return {
+          project: labels['com.docker.compose.project'] || undefined,
+          workingDir: labels['com.docker.compose.project.working_dir'] || undefined,
+          configFiles: this.parseConfigFiles(labels['com.docker.compose.project.config_files']),
+          service: labels['com.docker.compose.service'] || undefined,
+        };
+      } catch (error) {
+        // Not fatal: callers fall back to their own defaults and say so.
+        this.logger.warn(`Could not inspect the panel's own container (${containerId})`, error);
+      }
     }
+    return { configFiles: [] };
   }
 
   private parseConfigFiles(value?: string): string[] {

--- a/backend/src/common/docker/own-container.spec.ts
+++ b/backend/src/common/docker/own-container.spec.ts
@@ -1,0 +1,75 @@
+import { containerIdFromMountinfo, isInsideContainer, ownContainerIds } from './own-container';
+
+const ID = 'a'.repeat(64);
+const MOUNTINFO = [
+  '742 731 0:38 / / rw,relatime - overlay overlay rw,lowerdir=/var/lib/docker/overlay2/l/ABC',
+  `757 742 8:1 /var/lib/docker/containers/${ID}/resolv.conf /etc/resolv.conf rw,relatime - ext4 /dev/sda1 rw`,
+  `758 742 8:1 /var/lib/docker/containers/${ID}/hostname /etc/hostname rw,relatime - ext4 /dev/sda1 rw`,
+  `759 742 8:1 /var/lib/docker/containers/${ID}/hosts /etc/hosts rw,relatime - ext4 /dev/sda1 rw`,
+].join('\n');
+
+describe('own-container', () => {
+  const originalHostname = process.env.HOSTNAME;
+
+  afterEach(() => {
+    process.env.HOSTNAME = originalHostname;
+  });
+
+  describe('containerIdFromMountinfo', () => {
+    it('reads the full container id off the /etc/hostname bind', () => {
+      expect(containerIdFromMountinfo(MOUNTINFO)).toBe(ID);
+    });
+
+    it('accepts a custom data root', () => {
+      expect(containerIdFromMountinfo(`1 2 8:1 /mnt/docker/containers/${ID}/hostname /etc/hostname rw - ext4 /dev/sdb rw`)).toBe(ID);
+    });
+
+    it('returns undefined outside a container', () => {
+      expect(containerIdFromMountinfo('24 1 8:1 / / rw,relatime - ext4 /dev/sda1 rw')).toBeUndefined();
+      expect(containerIdFromMountinfo('')).toBeUndefined();
+    });
+
+    it('ignores paths that only look like a container dir', () => {
+      expect(containerIdFromMountinfo(`1 2 8:1 /containers/${ID}/data /data rw - ext4 /dev/sda1 rw`)).toBeUndefined();
+      expect(containerIdFromMountinfo('1 2 8:1 /containers/abc/hostname /etc/hostname rw - ext4 /dev/sda1 rw')).toBeUndefined();
+    });
+  });
+
+  describe('ownContainerIds', () => {
+    it('tries HOSTNAME first and the mountinfo id second', () => {
+      process.env.HOSTNAME = 'abc123def456';
+
+      expect(ownContainerIds(MOUNTINFO)).toEqual(['abc123def456', ID]);
+    });
+
+    // Watchtower copies the old Config, hostname included, so HOSTNAME names a
+    // container that no longer exists. mountinfo still has the right one.
+    it('still knows the id when HOSTNAME is stale', () => {
+      process.env.HOSTNAME = 'deadbeef0000';
+
+      expect(ownContainerIds(MOUNTINFO)).toContain(ID);
+    });
+
+    it('does not repeat an id HOSTNAME and mountinfo agree on', () => {
+      process.env.HOSTNAME = ID;
+
+      expect(ownContainerIds(MOUNTINFO)).toEqual([ID]);
+    });
+
+    it('is empty with no HOSTNAME and no container mounts', () => {
+      delete process.env.HOSTNAME;
+
+      expect(ownContainerIds('')).toEqual([]);
+    });
+  });
+
+  describe('isInsideContainer', () => {
+    it('is true when mountinfo shows a container id', () => {
+      expect(isInsideContainer(MOUNTINFO)).toBe(true);
+    });
+
+    it('is false on a plain host', () => {
+      expect(isInsideContainer('24 1 8:1 / / rw,relatime - ext4 /dev/sda1 rw')).toBe(false);
+    });
+  });
+});

--- a/backend/src/common/docker/own-container.ts
+++ b/backend/src/common/docker/own-container.ts
@@ -1,0 +1,35 @@
+import * as fs from 'node:fs';
+
+// Docker bind-mounts /etc/hostname, /etc/hosts and /etc/resolv.conf from
+// <data-root>/containers/<id>/, so mountinfo carries the full id of the running
+// container whatever HOSTNAME says, on cgroup v1 and v2 alike.
+const MOUNTINFO_ID = /\/containers\/([0-9a-f]{64})\/(?:hostname|hosts|resolv\.conf)(?=\s|$)/;
+
+export function containerIdFromMountinfo(mountinfo: string): string | undefined {
+  return MOUNTINFO_ID.exec(mountinfo)?.[1];
+}
+
+function readMountinfo(): string {
+  try {
+    return fs.readFileSync('/proc/self/mountinfo', 'utf8');
+  } catch {
+    return '';
+  }
+}
+
+/**
+ * Ids `docker inspect` may know this container by, most likely first.
+ *
+ * HOSTNAME is the short id Docker assigned at creation, but a tool that recreates
+ * the container by copying its old Config (Watchtower does) carries the *previous*
+ * id over as the hostname, so inspecting it answers "No such object" from inside
+ * the very container it names. The id in mountinfo is always the current one.
+ */
+export function ownContainerIds(mountinfo = readMountinfo()): string[] {
+  const ids = [process.env.HOSTNAME?.trim(), containerIdFromMountinfo(mountinfo)];
+  return [...new Set(ids.filter((id): id is string => !!id))];
+}
+
+export function isInsideContainer(mountinfo = readMountinfo()): boolean {
+  return fs.existsSync('/.dockerenv') || !!containerIdFromMountinfo(mountinfo);
+}

--- a/backend/src/config.spec.ts
+++ b/backend/src/config.spec.ts
@@ -131,6 +131,13 @@ describe('readOwnMounts', () => {
     expect(warn).toHaveBeenCalledWith(expect.stringContaining('No such object: stale'));
   });
 
+  it('treats an answer with no mounts as not ours inside a container', () => {
+    const inspect = jest.fn().mockReturnValue(JSON.stringify({ mounts: [], spec: [] }));
+
+    expect(readOwnMounts(['abc'], true, inspect)).toBeUndefined();
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('abc: no mounts'));
+  });
+
   it('gives up after the last attempt on a daemon that never answers', () => {
     const inspect = jest.fn(() => {
       throw timeout();

--- a/backend/src/config.spec.ts
+++ b/backend/src/config.spec.ts
@@ -1,4 +1,4 @@
-import { resolveHostPath, type DockerMount } from './config';
+import { readOwnMounts, resolveHostPath, type DockerMount } from './config';
 
 describe('resolveHostPath', () => {
   const bind = (source: string, destination: string): DockerMount => ({ Type: 'bind', Source: source, Destination: destination });
@@ -63,5 +63,93 @@ describe('resolveHostPath', () => {
   it('ignores mounts that do not contain the path', () => {
     expect(resolveHostPath([bind('/var/run/docker.sock', '/var/run/docker.sock')], '/app/servers')).toBeUndefined();
     expect(resolveHostPath([], '/app/servers')).toBeUndefined();
+  });
+});
+
+describe('readOwnMounts', () => {
+  const inspectOutput = JSON.stringify({
+    mounts: [{ Type: 'volume', Name: 'minepanel_data', Source: '/var/lib/docker/volumes/minepanel_data/_data', Destination: '/app/data' }],
+    spec: [{ Target: '/app/data', VolumeOptions: { Subpath: 'data' } }],
+  });
+  const noSuchObject = (id: string) => Object.assign(new Error(`Command failed: docker inspect ${id}`), { stderr: `Error: No such object: ${id}\n`, status: 1 });
+  const timeout = () => Object.assign(new Error('spawnSync docker ETIMEDOUT'), { code: 'ETIMEDOUT', signal: 'SIGTERM' });
+
+  let warn: jest.SpyInstance;
+
+  beforeEach(() => {
+    warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    warn.mockRestore();
+  });
+
+  it('copies the volume subpath onto the mount it belongs to', () => {
+    const inspect = jest.fn().mockReturnValue(inspectOutput);
+
+    expect(readOwnMounts(['abc'], true, inspect)).toEqual([expect.objectContaining({ Destination: '/app/data', Subpath: 'data' })]);
+  });
+
+  // The bug: a container recreated with the previous container's hostname made the
+  // inspect fail, and that was indistinguishable from running outside Docker.
+  it('falls through to the next id when the first one is not a container', () => {
+    const inspect = jest.fn((id: string) => {
+      if (id === 'stale') throw noSuchObject(id);
+      return inspectOutput;
+    });
+
+    expect(readOwnMounts(['stale', 'current'], true, inspect)).toHaveLength(1);
+    expect(inspect).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not retry an id the daemon does not know', () => {
+    const inspect = jest.fn((id: string) => {
+      throw noSuchObject(id);
+    });
+
+    readOwnMounts(['stale'], true, inspect, 3, 0);
+
+    expect(inspect).toHaveBeenCalledTimes(1);
+  });
+
+  it('retries when the daemon is too slow to answer', () => {
+    const inspect = jest.fn().mockImplementationOnce(() => {
+      throw timeout();
+    });
+    inspect.mockReturnValue(inspectOutput);
+
+    expect(readOwnMounts(['abc'], true, inspect, 3, 0)).toHaveLength(1);
+    expect(inspect).toHaveBeenCalledTimes(2);
+  });
+
+  it('reports unknown mounts, not "no mounts", when it is in a container it cannot inspect', () => {
+    const inspect = jest.fn((id: string) => {
+      throw noSuchObject(id);
+    });
+
+    expect(readOwnMounts(['stale'], true, inspect, 3, 0)).toBeUndefined();
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('No such object: stale'));
+  });
+
+  it('gives up after the last attempt on a daemon that never answers', () => {
+    const inspect = jest.fn(() => {
+      throw timeout();
+    });
+
+    expect(readOwnMounts(['abc'], true, inspect, 2, 0)).toBeUndefined();
+    expect(inspect).toHaveBeenCalledTimes(2);
+  });
+
+  it('treats a failed inspect outside a container as local dev', () => {
+    const inspect = jest.fn(() => {
+      throw new Error('spawnSync docker ENOENT');
+    });
+
+    expect(readOwnMounts(['my-laptop'], false, inspect)).toEqual([]);
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it('is empty outside a container with no id to try', () => {
+    expect(readOwnMounts([], false, jest.fn())).toEqual([]);
   });
 });

--- a/backend/src/config.ts
+++ b/backend/src/config.ts
@@ -89,7 +89,14 @@ export function readOwnMounts(
   for (const id of ids) {
     for (let attempt = 1; attempt <= attempts; attempt++) {
       try {
-        return parseMounts(inspect(id));
+        const mounts = parseMounts(inspect(id));
+        // Inside a container an answer with no mounts at all cannot be ours: the Docker
+        // socket alone is one. Treat it like an id the daemon does not know.
+        if (inContainer && mounts.length === 0) {
+          failures.push(`${id}: no mounts`);
+          break;
+        }
+        return mounts;
       } catch (error) {
         failures.push(`${id}: ${describeFailure(error)}`);
         if (!isTransient(error) || attempt === attempts) break;

--- a/backend/src/config.ts
+++ b/backend/src/config.ts
@@ -1,6 +1,6 @@
 import { execFileSync } from 'node:child_process';
 import * as path from 'node:path';
-import * as os from 'node:os';
+import { isInsideContainer, ownContainerIds } from './common/docker/own-container';
 
 export interface DockerMount {
   Type?: string;
@@ -30,35 +30,81 @@ interface MountSpec {
 // ever produce. It also keeps whatever path shape the platform reports (Docker Desktop
 // rewrites binds to /host_mnt/... and /run/desktop/...) intact, since the daemon is the
 // one resolving it back.
-function readOwnMounts(): DockerMount[] {
-  try {
-    const containerId = process.env.HOSTNAME || os.hostname();
-    // execFileSync, not execSync: HOSTNAME is whatever the container spec says, and there is
-    // no reason to hand it to a shell to reinterpret.
-    // .Mounts says what is mounted where; .HostConfig.Mounts is the request that produced it
-    // and the only place a volume subpath survives.
-    const stdout = execFileSync(
-      'docker',
-      ['inspect', containerId, '--format', '{"mounts":{{json .Mounts}},"spec":{{json .HostConfig.Mounts}}}'],
-      {
-        encoding: 'utf8',
-        stdio: ['ignore', 'pipe', 'ignore'],
-        timeout: 5000,
-      },
-    ).trim();
+function inspectMounts(containerId: string): string {
+  // execFileSync, not execSync: HOSTNAME is whatever the container spec says, and there is
+  // no reason to hand it to a shell to reinterpret.
+  // .Mounts says what is mounted where; .HostConfig.Mounts is the request that produced it
+  // and the only place a volume subpath survives.
+  return execFileSync(
+    'docker',
+    ['inspect', containerId, '--format', '{"mounts":{{json .Mounts}},"spec":{{json .HostConfig.Mounts}}}'],
+    {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+      timeout: 15000,
+    },
+  ).trim();
+}
 
-    const parsed = JSON.parse(stdout || '{}') as { mounts?: unknown; spec?: unknown };
-    const mounts = Array.isArray(parsed.mounts) ? (parsed.mounts as DockerMount[]) : [];
-    const spec = Array.isArray(parsed.spec) ? (parsed.spec as MountSpec[]) : [];
+function parseMounts(stdout: string): DockerMount[] {
+  const parsed = JSON.parse(stdout || '{}') as { mounts?: unknown; spec?: unknown };
+  const mounts = Array.isArray(parsed.mounts) ? (parsed.mounts as DockerMount[]) : [];
+  const spec = Array.isArray(parsed.spec) ? (parsed.spec as MountSpec[]) : [];
 
-    return mounts.map((mount) => {
-      const subpath = spec.find((entry) => entry.Target === mount.Destination)?.VolumeOptions?.Subpath;
-      return subpath ? { ...mount, Subpath: subpath } : mount;
-    });
-  } catch {
-    // Docker unavailable (e.g. local dev outside Docker) -> fall back to BASE_DIR.
-    return [];
+  return mounts.map((mount) => {
+    const subpath = spec.find((entry) => entry.Target === mount.Destination)?.VolumeOptions?.Subpath;
+    return subpath ? { ...mount, Subpath: subpath } : mount;
+  });
+}
+
+function describeFailure(error: unknown): string {
+  const failure = error as { stderr?: string; message?: string };
+  return (failure.stderr?.trim() || failure.message || String(error)).split('\n')[0];
+}
+
+// The daemon can be slow to answer right after an update, while it is still extracting
+// images, and the answer is fixed for the life of the process, so a timeout is worth a
+// second try. "No such object" is not: that id is simply not ours.
+function isTransient(error: unknown): boolean {
+  const failure = error as { code?: string; signal?: string };
+  return failure.code === 'ETIMEDOUT' || failure.signal === 'SIGTERM';
+}
+
+function pause(ms: number): void {
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
+}
+
+// `[]` means the panel is not running in a container, where BASE_DIR is the right answer.
+// `undefined` means it is, but could not find out what is mounted where: every host path
+// derived from here is then a guess, and the callers must treat it as one.
+export function readOwnMounts(
+  ids: string[],
+  inContainer: boolean,
+  inspect: (containerId: string) => string = inspectMounts,
+  attempts = 3,
+  retryDelayMs = 2000,
+): DockerMount[] | undefined {
+  const failures: string[] = [];
+
+  for (const id of ids) {
+    for (let attempt = 1; attempt <= attempts; attempt++) {
+      try {
+        return parseMounts(inspect(id));
+      } catch (error) {
+        failures.push(`${id}: ${describeFailure(error)}`);
+        if (!isTransient(error) || attempt === attempts) break;
+        pause(retryDelayMs);
+      }
+    }
   }
+
+  if (!inContainer) return [];
+
+  console.warn(
+    `[config] could not inspect the panel's own container to find its mounts (${failures.join('; ') || 'no container id known'}). ` +
+      'Host paths cannot be derived, so servers and mc-router will refuse to start until the panel is restarted with a working `docker inspect`.',
+  );
+  return undefined;
 }
 
 // The deepest mount containing `containerPath`, so a single volume mounted at /app resolves
@@ -99,7 +145,13 @@ export function resolveHostPath(mounts: DockerMount[], containerPath: string): s
 // should refuse rather than hand the daemon a path that does not exist.
 const unresolvedHostPaths: string[] = [];
 
-function detectHostDir(mounts: DockerMount[], containerPath: string, fallback: string): string {
+function detectHostDir(mounts: DockerMount[] | undefined, containerPath: string, fallback: string): string {
+  if (!mounts) {
+    unresolvedHostPaths.push(containerPath);
+    console.warn(`[config] the host path of ${containerPath} is unknown. Falling back to "${fallback}", which is a path inside this container, not on the host.`);
+    return fallback;
+  }
+
   const detected = resolveHostPath(mounts, containerPath);
   if (!detected) {
     // No mounts at all means we are not in a container (local dev), where BASE_DIR is a
@@ -124,7 +176,7 @@ function detectHostDir(mounts: DockerMount[], containerPath: string, fallback: s
 
 // Resolved once at import: the factory below can be called more than once, and detection
 // shells out to `docker inspect` and warns on the way.
-const ownMounts = readOwnMounts();
+const ownMounts = readOwnMounts(ownContainerIds(), isInsideContainer());
 const envBaseDir = process.env.BASE_DIR || '/app';
 const serversHostDir = detectHostDir(ownMounts, '/app/servers', path.join(envBaseDir, 'servers'));
 const dataHostDir = detectHostDir(ownMounts, '/app/data', path.join(envBaseDir, 'data'));

--- a/backend/src/server-management/server-management.service.spec.ts
+++ b/backend/src/server-management/server-management.service.spec.ts
@@ -268,6 +268,51 @@ describe('ServerManagementService', () => {
 
   });
 
+  // Every mount in the compose file is a host path under serversHostDir. When the panel
+  // could not resolve it, starting would bind an empty directory and the server would
+  // write a fresh world into it.
+  describe('with an unresolved host path for /app/servers', () => {
+    let guessing: ServerManagementService;
+
+    beforeEach(async () => {
+      const module: TestingModule = await Test.createTestingModule({
+        providers: [
+          ServerManagementService,
+          {
+            provide: ConfigService,
+            useValue: {
+              get: jest.fn((key: string) => {
+                if (key === 'serversDir') return SERVERS_DIR;
+                if (key === 'serversHostDir') return '/app/servers';
+                if (key === 'unresolvedHostPaths') return ['/app/servers'];
+                return null;
+              }),
+            },
+          },
+          { provide: getRepositoryToken(Settings), useValue: { findOne: jest.fn().mockResolvedValue(null) } },
+          { provide: DiscordService, useValue: { sendServerNotification: jest.fn() } },
+          { provide: AlertsService, useValue: { markExpectedStop: jest.fn() } },
+          { provide: ServerStoreService, useValue: { readConfig: jest.fn() } },
+          { provide: DockerComposeService, useValue: { refreshComposeFile: jest.fn().mockResolvedValue(true) } },
+          { provide: InstanceSettingsService, useValue: {} },
+        ],
+      }).compile();
+
+      guessing = module.get(ServerManagementService);
+      (fs.pathExists as jest.Mock).mockResolvedValue(true);
+    });
+
+    it('refuses to start a server instead of binding a guessed path', async () => {
+      expect(await guessing.startServer('myserver')).toBe(false);
+      expect(mockExec).not.toHaveBeenCalled();
+    });
+
+    it('refuses to restart a server for the same reason', async () => {
+      expect(await guessing.restartServer('myserver')).toBe(false);
+      expect(mockExec).not.toHaveBeenCalled();
+    });
+  });
+
   describe('stopServer', () => {
     it('should fail for invalid server ID', async () => {
       const result = await service.stopServer('invalid;id');

--- a/backend/src/server-management/server-management.service.ts
+++ b/backend/src/server-management/server-management.service.ts
@@ -121,6 +121,7 @@ export class ServerManagementService {
   private readonly logger = new Logger(ServerManagementService.name);
   private readonly SERVERS_DIR: string;
   private readonly SERVERS_HOST_DIR: string;
+  private readonly SERVERS_HOST_DIR_IS_A_GUESS: boolean;
   private readonly COMPOSE_PROJECT?: string;
   private readonly RESERVED_SERVER_DIRS = new Set(['.world']);
 
@@ -146,6 +147,7 @@ export class ServerManagementService {
   ) {
     this.SERVERS_DIR = this.configService.get('serversDir');
     this.SERVERS_HOST_DIR = this.configService.get('serversHostDir');
+    this.SERVERS_HOST_DIR_IS_A_GUESS = (this.configService.get<string[]>('unresolvedHostPaths') ?? []).includes('/app/servers');
     this.COMPOSE_PROJECT = this.configService.get<string>('composeProject')?.trim() || undefined;
     fs.ensureDirSync(this.SERVERS_DIR);
     fs.ensureDirSync(this.getGlobalWorldsPath());
@@ -772,6 +774,19 @@ export class ServerManagementService {
     return '';
   }
 
+  // Every mount in a server's compose file is a host path under SERVERS_HOST_DIR. With a
+  // guessed one the daemon would create an empty bind source and the server would write a
+  // fresh world into it, which is worse than not starting at all.
+  private hostDirIsKnown(serverId: string): boolean {
+    if (!this.SERVERS_HOST_DIR_IS_A_GUESS) return true;
+
+    this.logger.error(
+      `Refusing to start server ${serverId}: the host path of /app/servers is unknown, so "${path.join(this.SERVERS_HOST_DIR, serverId)}" is a guess and the server would run against an empty directory. ` +
+        'See the [config] warnings at startup and restart the panel.',
+    );
+    return false;
+  }
+
   async restartServer(serverId: string): Promise<boolean> {
     try {
       if (!this.validateServerId(serverId)) {
@@ -782,6 +797,10 @@ export class ServerManagementService {
       const dockerComposePath = this.getDockerComposePath(serverId);
       if (!(await fs.pathExists(dockerComposePath))) {
         this.logger.error(`Docker compose file does not exist for server ${serverId}`);
+        return false;
+      }
+
+      if (!this.hostDirIsKnown(serverId)) {
         return false;
       }
 
@@ -1721,6 +1740,10 @@ export class ServerManagementService {
       const dockerComposePath = this.getDockerComposePath(serverId);
       if (!(await fs.pathExists(dockerComposePath))) {
         this.logger.error(`Docker compose file does not exist for server ${serverId}`);
+        return false;
+      }
+
+      if (!this.hostDirIsKnown(serverId)) {
         return false;
       }
 

--- a/doc/troubleshooting.md
+++ b/doc/troubleshooting.md
@@ -412,8 +412,9 @@ docker compose up -d --force-recreate backend
 ```
 
 `docker restart` is not enough: it keeps the stale hostname. If a server was started against
-the empty directory, its real data is still under your `servers/<id>/mc-data`; the empty copy is
-at the literal `/app/servers/<id>` path on the host and can be deleted.
+the empty directory, its real data is still in whatever backs `/app/servers`: `servers/<id>/mc-data`
+for a bind mount, `<volume>/_data/<id>/mc-data` for a named volume. The empty copy is at the
+literal `/app/servers/<id>` path on the host and can be deleted.
 
 ### A server is missing from the dashboard
 

--- a/doc/troubleshooting.md
+++ b/doc/troubleshooting.md
@@ -386,6 +386,35 @@ Volumes on a non-local driver (NFS, CIFS) cannot be resolved this way. The panel
 startup and falls back to `BASE_DIR`; use a bind mount for those.
 :::
 
+### Servers or mc-router mount `/app/servers/...` or `/app/data/...` after an auto-update
+
+**Symptoms:** The panel worked until Watchtower (or a script that recreates the container)
+updated it. Afterwards the generated mc-router compose file mounts `/app/data/proxy:/data`, or a
+server's compose file mounts `/app/servers/<id>/mc-data`, and the container finds an empty
+directory: mc-router crash-loops on a missing `routes.json`, a server generates a fresh world.
+
+**Cause:** The panel asks Docker about its own mounts with `docker inspect $HOSTNAME`. Docker
+sets `HOSTNAME` to the container id at creation, but Watchtower recreates the container by
+copying its old configuration, hostname included, so the recreated panel carries the *previous*
+container's id and the inspect fails. Before 1.12.11 that failure looked the same as running
+outside Docker, so the panel fell back to its own container paths and wrote them into the
+compose files as if they were host paths.
+
+**Solution:** From 1.12.11 the panel also reads its id from `/proc/self/mountinfo`, which
+survives recreation, and when it cannot inspect itself at all it refuses to start servers or
+mc-router instead of guessing. The startup log says which id it tried and why it failed.
+
+On an older version, or to recover: recreate the panel with Compose so it gets a fresh id and
+start the affected servers again (their compose files are regenerated on every start):
+
+```bash
+docker compose up -d --force-recreate backend
+```
+
+`docker restart` is not enough: it keeps the stale hostname. If a server was started against
+the empty directory, its real data is still under your `servers/<id>/mc-data`; the empty copy is
+at the literal `/app/servers/<id>` path on the host and can be deleted.
+
 ### A server is missing from the dashboard
 
 The list is built from `servers/servers.json`, an index the panel rebuilds from the folders.


### PR DESCRIPTION
## Problem

Watchtower (and anything that recreates a container by copying its old `Config`) carries the previous container id over as `HOSTNAME`. `docker inspect $HOSTNAME` then answers "No such object" from inside the very container it names.

That failure looked the same as "not running in Docker", so the panel fell back to its own container paths and wrote `/app/servers/<id>` and `/app/data/proxy` into the generated compose files as if they were host paths. Result after an auto-update: servers start against an empty directory (fresh world) and mc-router crash-loops on a missing `routes.json`.

## Fix

- `common/docker/own-container.ts`: also read the id from `/proc/self/mountinfo` (Docker bind-mounts `/etc/hostname|hosts|resolv.conf` from `<data-root>/containers/<id>/`, so it is always the *current* id, cgroup v1 and v2). `HOSTNAME` is tried first, mountinfo second.
- `config.ts`: `readOwnMounts` now distinguishes "outside a container" (`[]`, `BASE_DIR` is right) from "inside one we cannot inspect" (`undefined`). The latter puts `/app/servers` and `/app/data` in `unresolvedHostPaths`. Transient inspect timeouts right after an update are retried.
- `ServerManagementService.startServer`/`restartServer` refuse to run while the servers host path is a guess, with a log line pointing at the `[config]` warnings.
- `HostContextService` (used by the self-updater and mc-router) tries every known id.
- `doc/troubleshooting.md`: new section with symptoms, cause and recovery (`docker compose up -d --force-recreate backend`; `docker restart` keeps the stale hostname).
- `backend/AGENTS.md`: never `docker inspect $HOSTNAME` directly; use `ownContainerIds()` and honour `unresolvedHostPaths`.

## Also in this PR: backend image built natively

`backend/Dockerfile` now runs the `builder` stage on `$BUILDPLATFORM`. The arm64 build used to run `pnpm install/build/deploy` under QEMU, where node crashed with `SIGILL` and buildkit hung until the 6h job limit; that is how v1.12.10 got tagged without a backend image (the `release` job has since been fixed on `main` to require all three images). Nothing in the builder is target-specific: `bcrypt` bundles musl prebuilds for x64 and arm64 and picks one at runtime. Verified locally with `docker buildx build --platform linux/arm64|linux/amd64`: both images load `bcrypt` and hash/compare correctly.

## Notes

- The troubleshooting page says "from 1.12.11" assuming this is the next merge to `main` after v1.12.10; bump it if something else lands first.
- `pnpm verify` green locally: 68 suites, 771 tests, 95% statements.

https://claude.ai/code/session_01XCjEhvVgSJAbyF7vGA536e

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved container detection after automatic updates and container recreations.
  - Added retries for temporary Docker inspection failures.
  - Prevented servers and routing services from starting when host paths cannot be verified.
  - Avoided creating misleading empty directories when storage locations are unresolved.
  - Improved handling of Docker mount detection both inside and outside containers.

- **Documentation**
  - Clarified server data locations for bind mounts and named volumes.
  - Added guidance for safely recovering from stale container identity issues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->