### PR TITLE
fix(files): validate the server id before building a path

### DIFF
--- a/backend/AGENTS.md
+++ b/backend/AGENTS.md
@@ -251,7 +251,11 @@ Files module behavior:
 - `serverId="_root"` maps to `/app/servers` in files API.
 - `serverId=".world"` maps to `/app/servers/.world/worlds` in files API.
 - Other server IDs map to `/app/servers/<serverId>/mc-data`.
-- Preserve traversal protection (`normalize` + `startsWith(basePath)`).
+- Preserve traversal protection (`normalize` + `startsWith(basePath + path.sep)`, or equal to it).
+  A bare `startsWith(basePath)` lets `_root` reach siblings such as `/app/servers-old`.
+- `serverId` is a percent-decoded route param (`..%2F` arrives as `../`), so any other id must
+  match `^[a-zA-Z0-9_-]+$` before it is joined into a path. Checking containment against a base
+  built from it proves nothing.
 
 Data migration and compatibility:
 

--- a/backend/src/files/files.service.spec.ts
+++ b/backend/src/files/files.service.spec.ts
@@ -51,6 +51,17 @@ describe('FilesService', () => {
     it('should reject path traversal that escapes the base directory', () => {
       expect(() => service.getFullPath('srv', '../../../etc/passwd')).toThrow(BadRequestException);
     });
+
+    it('should reject a server id that is not a plain folder name', () => {
+      for (const serverId of ['../outside', '../../tmp/x', 'a/b', '..', '']) {
+        expect(() => service.getFullPath(serverId, 'file.txt')).toThrow(BadRequestException);
+      }
+    });
+
+    it('should reject paths that escape into a sibling of the base directory', () => {
+      expect(() => service.getFullPath('_root', '../servers-evil/secret.txt')).toThrow(BadRequestException);
+      expect(() => service.getFullPath('.world', '../worlds-old')).toThrow(BadRequestException);
+    });
   });
 
   describe('listFiles', () => {

--- a/backend/src/files/files.service.ts
+++ b/backend/src/files/files.service.ts
@@ -4,6 +4,8 @@ import * as fs from 'fs-extra';
 import * as path from 'path';
 import * as archiver from 'archiver';
 
+const SERVER_ID_PATTERN = /^[a-zA-Z0-9_-]+$/;
+
 export interface FileItem {
   name: string;
   path: string;
@@ -33,6 +35,11 @@ export class FilesService {
       return path.join(this.SERVERS_DIR, '.world', 'worlds');
     }
 
+    // serverId is a decoded route param ("..%2F" arrives as "../"), so it must never shape the base path
+    if (!SERVER_ID_PATTERN.test(serverId)) {
+      throw new BadRequestException('Invalid server id');
+    }
+
     return path.join(this.SERVERS_DIR, serverId, 'mc-data');
   }
 
@@ -41,8 +48,8 @@ export class FilesService {
     const fullPath = path.join(basePath, filePath || '');
     const normalized = path.normalize(fullPath);
 
-    // Prevent path traversal attacks
-    if (!normalized.startsWith(basePath)) {
+    // Prevent path traversal attacks; the separator keeps siblings like "servers-old" out
+    if (normalized !== basePath && !normalized.startsWith(basePath + path.sep)) {
       throw new BadRequestException('Invalid path');
     }
 


### PR DESCRIPTION
## Description

Tightens path validation in the files API.

- `getBasePath` now requires any server id other than `_root` / `.world` to match `^[a-zA-Z0-9_-]+$` before it is joined into a path, the same constraint the lifecycle endpoints already use. The route param arrives percent-decoded, so the containment check alone is not enough when the base itself is built from it.
- `validatePath` compares against `basePath + path.sep` (or the base itself) instead of a bare `startsWith(basePath)`, so a sibling directory whose name shares the prefix (e.g. `servers-old`) is no longer considered inside the base.
- `backend/AGENTS.md` documents both rules.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] 🧪 Tests

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have tested my changes locally
- [x] I have updated documentation if needed
- [x] My changes don't introduce new warnings or errors

`pnpm verify` green: 70 suites, 802 tests, 95.5% lines.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved file path validation to reject invalid server identifiers.
  - Prevented traversal attempts into sibling directories and restricted file access to the intended server directory.
  - Added coverage for invalid identifiers and traversal scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->